### PR TITLE
crawl for geom_alt prop updates

### DIFF
--- a/data/421/166/987/421166987.geojson
+++ b/data/421/166/987/421166987.geojson
@@ -201,6 +201,9 @@
     },
     "wof:country":"TZ",
     "wof:created":1459008710,
+    "wof:geom_alt":[
+        "naturalearth"
+    ],
     "wof:geomhash":"22721a8fc98b7490ad5b4a6f385f3403",
     "wof:hierarchy":[
         {
@@ -212,7 +215,7 @@
         }
     ],
     "wof:id":421166987,
-    "wof:lastmodified":1566590806,
+    "wof:lastmodified":1582347607,
     "wof:name":"Korogwe",
     "wof:parent_id":1108692931,
     "wof:placetype":"locality",

--- a/data/421/170/113/421170113.geojson
+++ b/data/421/170/113/421170113.geojson
@@ -105,6 +105,9 @@
     },
     "wof:country":"TZ",
     "wof:created":1459008837,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7a8096eee4d32feaa58578e64603325b",
     "wof:hierarchy":[
         {
@@ -115,7 +118,7 @@
         }
     ],
     "wof:id":421170113,
-    "wof:lastmodified":1566590830,
+    "wof:lastmodified":1582347614,
     "wof:name":"Mbeya Urban",
     "wof:parent_id":85679641,
     "wof:placetype":"county",

--- a/data/421/170/243/421170243.geojson
+++ b/data/421/170/243/421170243.geojson
@@ -113,6 +113,9 @@
     },
     "wof:country":"TZ",
     "wof:created":1459008845,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a48f0f241524b3f4f5ca16591af776e8",
     "wof:hierarchy":[
         {
@@ -123,7 +126,7 @@
         }
     ],
     "wof:id":421170243,
-    "wof:lastmodified":1566590829,
+    "wof:lastmodified":1582347614,
     "wof:name":"Serengeti",
     "wof:parent_id":85679743,
     "wof:placetype":"county",

--- a/data/421/170/423/421170423.geojson
+++ b/data/421/170/423/421170423.geojson
@@ -296,6 +296,9 @@
     },
     "wof:country":"TZ",
     "wof:created":1459008852,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"a46773ba50588b8e89a65ac095e1d41f",
     "wof:hierarchy":[
         {
@@ -307,7 +310,7 @@
         }
     ],
     "wof:id":421170423,
-    "wof:lastmodified":1566590830,
+    "wof:lastmodified":1582347614,
     "wof:name":"Songea",
     "wof:parent_id":1108692991,
     "wof:placetype":"locality",

--- a/data/421/170/433/421170433.geojson
+++ b/data/421/170/433/421170433.geojson
@@ -207,6 +207,9 @@
     },
     "wof:country":"TZ",
     "wof:created":1459008853,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"5ea216ebc7db415824873432f4b01b28",
     "wof:hierarchy":[
         {
@@ -218,7 +221,7 @@
         }
     ],
     "wof:id":421170433,
-    "wof:lastmodified":1566590830,
+    "wof:lastmodified":1582347614,
     "wof:name":"Chake Chake",
     "wof:parent_id":421187955,
     "wof:placetype":"locality",

--- a/data/421/170/445/421170445.geojson
+++ b/data/421/170/445/421170445.geojson
@@ -291,6 +291,9 @@
     },
     "wof:country":"TZ",
     "wof:created":1459008853,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"8ff4160f67cdecd92e8e31ee54586d8e",
     "wof:hierarchy":[
         {
@@ -301,7 +304,7 @@
         }
     ],
     "wof:id":421170445,
-    "wof:lastmodified":1566590830,
+    "wof:lastmodified":1582347614,
     "wof:name":"Musoma",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/421/171/039/421171039.geojson
+++ b/data/421/171/039/421171039.geojson
@@ -107,6 +107,9 @@
     },
     "wof:country":"TZ",
     "wof:created":1459008879,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"dcec1a6dfda07bca5a36fb6cc8d84594",
     "wof:hierarchy":[
         {
@@ -117,7 +120,7 @@
         }
     ],
     "wof:id":421171039,
-    "wof:lastmodified":1566590839,
+    "wof:lastmodified":1582347618,
     "wof:name":"Hanang",
     "wof:parent_id":85679733,
     "wof:placetype":"county",

--- a/data/421/171/043/421171043.geojson
+++ b/data/421/171/043/421171043.geojson
@@ -99,6 +99,9 @@
     },
     "wof:country":"TZ",
     "wof:created":1459008879,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"221b71d701a724e0c5b056ae145e697d",
     "wof:hierarchy":[
         {
@@ -109,7 +112,7 @@
         }
     ],
     "wof:id":421171043,
-    "wof:lastmodified":1566590839,
+    "wof:lastmodified":1582347618,
     "wof:name":"Moshi",
     "wof:parent_id":85679737,
     "wof:placetype":"county",

--- a/data/421/171/979/421171979.geojson
+++ b/data/421/171/979/421171979.geojson
@@ -125,6 +125,9 @@
     },
     "wof:country":"TZ",
     "wof:created":1459008914,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"fd625df1506c5122c74505b8df7ebd5b",
     "wof:hierarchy":[
         {
@@ -135,7 +138,7 @@
         }
     ],
     "wof:id":421171979,
-    "wof:lastmodified":1566590839,
+    "wof:lastmodified":1582347618,
     "wof:name":"Ngorongoro",
     "wof:parent_id":85679731,
     "wof:placetype":"county",

--- a/data/421/171/981/421171981.geojson
+++ b/data/421/171/981/421171981.geojson
@@ -108,6 +108,9 @@
     },
     "wof:country":"TZ",
     "wof:created":1459008914,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e471833fe77144da14d4ad094d6b9999",
     "wof:hierarchy":[
         {
@@ -118,7 +121,7 @@
         }
     ],
     "wof:id":421171981,
-    "wof:lastmodified":1566590840,
+    "wof:lastmodified":1582347618,
     "wof:name":"Rombo",
     "wof:parent_id":85679737,
     "wof:placetype":"county",

--- a/data/421/175/227/421175227.geojson
+++ b/data/421/175/227/421175227.geojson
@@ -114,6 +114,9 @@
     },
     "wof:country":"TZ",
     "wof:created":1459009060,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"024726ac980214a41b9cc0ae156fae82",
     "wof:hierarchy":[
         {
@@ -124,7 +127,7 @@
         }
     ],
     "wof:id":421175227,
-    "wof:lastmodified":1566590822,
+    "wof:lastmodified":1582347612,
     "wof:name":"Arusha",
     "wof:parent_id":85679731,
     "wof:placetype":"county",

--- a/data/421/175/229/421175229.geojson
+++ b/data/421/175/229/421175229.geojson
@@ -100,6 +100,9 @@
     },
     "wof:country":"TZ",
     "wof:created":1459009060,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"15f29fc6302b5e5f6be407e8bfd6e3f4",
     "wof:hierarchy":[
         {
@@ -110,7 +113,7 @@
         }
     ],
     "wof:id":421175229,
-    "wof:lastmodified":1566590821,
+    "wof:lastmodified":1582347612,
     "wof:name":"Lushoto",
     "wof:parent_id":85679747,
     "wof:placetype":"county",

--- a/data/421/175/441/421175441.geojson
+++ b/data/421/175/441/421175441.geojson
@@ -110,6 +110,9 @@
     },
     "wof:country":"TZ",
     "wof:created":1459009067,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ea024f67e7c9d46c2d7817e75fb1d7fd",
     "wof:hierarchy":[
         {
@@ -120,7 +123,7 @@
         }
     ],
     "wof:id":421175441,
-    "wof:lastmodified":1566590822,
+    "wof:lastmodified":1582347612,
     "wof:name":"Tarime",
     "wof:parent_id":85679743,
     "wof:placetype":"county",

--- a/data/421/177/209/421177209.geojson
+++ b/data/421/177/209/421177209.geojson
@@ -335,6 +335,9 @@
     },
     "wof:country":"TZ",
     "wof:created":1459009136,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"9b3af3f63762853fb798340b4239a739",
     "wof:hierarchy":[
         {
@@ -346,7 +349,7 @@
         }
     ],
     "wof:id":421177209,
-    "wof:lastmodified":1566590830,
+    "wof:lastmodified":1582347614,
     "wof:name":"Morogoro",
     "wof:parent_id":1108692939,
     "wof:placetype":"locality",

--- a/data/421/177/213/421177213.geojson
+++ b/data/421/177/213/421177213.geojson
@@ -228,6 +228,9 @@
     },
     "wof:country":"TZ",
     "wof:created":1459009136,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"b7b4d0f4b29220a028d18d0f54a90081",
     "wof:hierarchy":[
         {
@@ -239,7 +242,7 @@
         }
     ],
     "wof:id":421177213,
-    "wof:lastmodified":1566590830,
+    "wof:lastmodified":1582347614,
     "wof:name":"Singida",
     "wof:parent_id":1108693027,
     "wof:placetype":"locality",

--- a/data/421/178/387/421178387.geojson
+++ b/data/421/178/387/421178387.geojson
@@ -105,6 +105,9 @@
     },
     "wof:country":"TZ",
     "wof:created":1459009180,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b2bf8d00313e28cab603440444bd8dad",
     "wof:hierarchy":[
         {
@@ -115,7 +118,7 @@
         }
     ],
     "wof:id":421178387,
-    "wof:lastmodified":1566590833,
+    "wof:lastmodified":1582347615,
     "wof:name":"Simanjiro",
     "wof:parent_id":85679733,
     "wof:placetype":"county",

--- a/data/421/178/419/421178419.geojson
+++ b/data/421/178/419/421178419.geojson
@@ -64,6 +64,9 @@
     },
     "wof:country":"TZ",
     "wof:created":1459009181,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"566bef6b9976ad351ae8713271d5fcdc",
     "wof:hierarchy":[
         {
@@ -75,7 +78,7 @@
         }
     ],
     "wof:id":421178419,
-    "wof:lastmodified":1566590832,
+    "wof:lastmodified":1582347615,
     "wof:name":"Katoro",
     "wof:parent_id":1108693087,
     "wof:placetype":"locality",

--- a/data/421/180/247/421180247.geojson
+++ b/data/421/180/247/421180247.geojson
@@ -91,6 +91,9 @@
     },
     "wof:country":"TZ",
     "wof:created":1459009249,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"691371b64a90ddd282632582ca2f5346",
     "wof:hierarchy":[
         {
@@ -101,7 +104,7 @@
         }
     ],
     "wof:id":421180247,
-    "wof:lastmodified":1566590814,
+    "wof:lastmodified":1582347609,
     "wof:name":"Kigoma Rural",
     "wof:parent_id":85679669,
     "wof:placetype":"county",

--- a/data/421/181/605/421181605.geojson
+++ b/data/421/181/605/421181605.geojson
@@ -299,6 +299,9 @@
     },
     "wof:country":"TZ",
     "wof:created":1459009301,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"1112b08dae1640f001ccbfac194d949f",
     "wof:hierarchy":[
         {
@@ -310,7 +313,7 @@
         }
     ],
     "wof:id":421181605,
-    "wof:lastmodified":1566590821,
+    "wof:lastmodified":1582347612,
     "wof:name":"Iringa",
     "wof:parent_id":421198449,
     "wof:placetype":"locality",

--- a/data/421/182/255/421182255.geojson
+++ b/data/421/182/255/421182255.geojson
@@ -97,6 +97,9 @@
     },
     "wof:country":"TZ",
     "wof:created":1459009323,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ceb1f744f0b8b4f99eff6bf70d42528e",
     "wof:hierarchy":[
         {
@@ -107,7 +110,7 @@
         }
     ],
     "wof:id":421182255,
-    "wof:lastmodified":1566590834,
+    "wof:lastmodified":1582347615,
     "wof:name":"Rufiji",
     "wof:parent_id":85679691,
     "wof:placetype":"county",

--- a/data/421/183/841/421183841.geojson
+++ b/data/421/183/841/421183841.geojson
@@ -90,6 +90,9 @@
     },
     "wof:country":"TZ",
     "wof:created":1459009389,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2f80091aa3f40ba245c40c79c6c2e0a2",
     "wof:hierarchy":[
         {
@@ -100,7 +103,7 @@
         }
     ],
     "wof:id":421183841,
-    "wof:lastmodified":1566590831,
+    "wof:lastmodified":1582347614,
     "wof:name":"Mkuranga",
     "wof:parent_id":85679691,
     "wof:placetype":"county",

--- a/data/421/185/287/421185287.geojson
+++ b/data/421/185/287/421185287.geojson
@@ -296,6 +296,9 @@
     },
     "wof:country":"TZ",
     "wof:created":1459009438,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"9054ba84902ab94c43472e0845ba468c",
     "wof:hierarchy":[
         {
@@ -307,7 +310,7 @@
         }
     ],
     "wof:id":421185287,
-    "wof:lastmodified":1566590840,
+    "wof:lastmodified":1582347618,
     "wof:name":"Tabora",
     "wof:parent_id":1108693045,
     "wof:placetype":"locality",

--- a/data/421/186/277/421186277.geojson
+++ b/data/421/186/277/421186277.geojson
@@ -107,6 +107,9 @@
     },
     "wof:country":"TZ",
     "wof:created":1459009476,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"fdfa959c2c0d472a505d4857f633a52c",
     "wof:hierarchy":[
         {
@@ -117,7 +120,7 @@
         }
     ],
     "wof:id":421186277,
-    "wof:lastmodified":1566590820,
+    "wof:lastmodified":1582347612,
     "wof:name":"Manyoni",
     "wof:parent_id":85679727,
     "wof:placetype":"county",

--- a/data/421/187/711/421187711.geojson
+++ b/data/421/187/711/421187711.geojson
@@ -126,6 +126,9 @@
     },
     "wof:country":"TZ",
     "wof:created":1459009521,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ffd11c6458e39abf58b5522861b1076f",
     "wof:hierarchy":[
         {
@@ -136,7 +139,7 @@
         }
     ],
     "wof:id":421187711,
-    "wof:lastmodified":1566590818,
+    "wof:lastmodified":1582347611,
     "wof:name":"Karatu",
     "wof:parent_id":85679731,
     "wof:placetype":"county",

--- a/data/421/187/951/421187951.geojson
+++ b/data/421/187/951/421187951.geojson
@@ -119,6 +119,9 @@
     },
     "wof:country":"TZ",
     "wof:created":1459009529,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"287a2f3bed802330c1b18bb5b517387c",
     "wof:hierarchy":[
         {
@@ -129,7 +132,7 @@
         }
     ],
     "wof:id":421187951,
-    "wof:lastmodified":1566590817,
+    "wof:lastmodified":1582347611,
     "wof:name":"Bariadi",
     "wof:parent_id":85679755,
     "wof:placetype":"county",

--- a/data/421/187/953/421187953.geojson
+++ b/data/421/187/953/421187953.geojson
@@ -116,6 +116,9 @@
     },
     "wof:country":"TZ",
     "wof:created":1459009529,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"5739dcf5641332969131c4c23546248c",
     "wof:hierarchy":[
         {
@@ -126,7 +129,7 @@
         }
     ],
     "wof:id":421187953,
-    "wof:lastmodified":1566590814,
+    "wof:lastmodified":1582347610,
     "wof:name":"Bunda",
     "wof:parent_id":85679743,
     "wof:placetype":"county",

--- a/data/421/187/955/421187955.geojson
+++ b/data/421/187/955/421187955.geojson
@@ -91,6 +91,9 @@
     },
     "wof:country":"TZ",
     "wof:created":1459009529,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"96509e25c93a8fd807fe351da0e00836",
     "wof:hierarchy":[
         {
@@ -101,7 +104,7 @@
         }
     ],
     "wof:id":421187955,
-    "wof:lastmodified":1566590815,
+    "wof:lastmodified":1582347610,
     "wof:name":"Chake Chake",
     "wof:parent_id":85679687,
     "wof:placetype":"county",

--- a/data/421/187/957/421187957.geojson
+++ b/data/421/187/957/421187957.geojson
@@ -108,6 +108,9 @@
     },
     "wof:country":"TZ",
     "wof:created":1459009529,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"4e11fb8b8b0ce47816df69e39c25b494",
     "wof:hierarchy":[
         {
@@ -118,7 +121,7 @@
         }
     ],
     "wof:id":421187957,
-    "wof:lastmodified":1566590816,
+    "wof:lastmodified":1582347610,
     "wof:name":"Dodoma Urban",
     "wof:parent_id":85679705,
     "wof:placetype":"county",

--- a/data/421/187/959/421187959.geojson
+++ b/data/421/187/959/421187959.geojson
@@ -108,6 +108,9 @@
     },
     "wof:country":"TZ",
     "wof:created":1459009529,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"1cc965c7fce591670a0c43e6f39cff01",
     "wof:hierarchy":[
         {
@@ -118,7 +121,7 @@
         }
     ],
     "wof:id":421187959,
-    "wof:lastmodified":1566590817,
+    "wof:lastmodified":1582347611,
     "wof:name":"Iringa Rural",
     "wof:parent_id":85679711,
     "wof:placetype":"county",

--- a/data/421/187/961/421187961.geojson
+++ b/data/421/187/961/421187961.geojson
@@ -122,6 +122,9 @@
     },
     "wof:country":"TZ",
     "wof:created":1459009529,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"195a3c65484a21c401e86d8ae1629d63",
     "wof:hierarchy":[
         {
@@ -132,7 +135,7 @@
         }
     ],
     "wof:id":421187961,
-    "wof:lastmodified":1566590816,
+    "wof:lastmodified":1582347610,
     "wof:name":"Kilwa",
     "wof:parent_id":85679713,
     "wof:placetype":"county",

--- a/data/421/188/197/421188197.geojson
+++ b/data/421/188/197/421188197.geojson
@@ -90,6 +90,9 @@
     },
     "wof:country":"TZ",
     "wof:created":1459009537,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"645a28c85cb36fac92cb003d7b6b652e",
     "wof:hierarchy":[
         {
@@ -100,7 +103,7 @@
         }
     ],
     "wof:id":421188197,
-    "wof:lastmodified":1566590820,
+    "wof:lastmodified":1582347611,
     "wof:name":"Kusini",
     "wof:parent_id":85679651,
     "wof:placetype":"county",

--- a/data/421/188/919/421188919.geojson
+++ b/data/421/188/919/421188919.geojson
@@ -175,6 +175,9 @@
     },
     "wof:country":"TZ",
     "wof:created":1459009588,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"0fe9a8e1bb7432138c3069c33d6cec49",
     "wof:hierarchy":[
         {
@@ -185,7 +188,7 @@
         }
     ],
     "wof:id":421188919,
-    "wof:lastmodified":1566590820,
+    "wof:lastmodified":1582347612,
     "wof:name":"Musoma",
     "wof:parent_id":85679743,
     "wof:placetype":"county",

--- a/data/421/188/923/421188923.geojson
+++ b/data/421/188/923/421188923.geojson
@@ -161,6 +161,9 @@
     },
     "wof:country":"TZ",
     "wof:created":1459009588,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"0721adbba08e099497472925fd384878",
     "wof:hierarchy":[
         {
@@ -171,7 +174,7 @@
         }
     ],
     "wof:id":421188923,
-    "wof:lastmodified":1566590819,
+    "wof:lastmodified":1582347611,
     "wof:name":"Tanga",
     "wof:parent_id":85679747,
     "wof:placetype":"county",

--- a/data/421/189/811/421189811.geojson
+++ b/data/421/189/811/421189811.geojson
@@ -302,6 +302,9 @@
     },
     "wof:country":"TZ",
     "wof:created":1459009637,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"31d2606b514e1acd36242f012a24b080",
     "wof:hierarchy":[
         {
@@ -313,7 +316,7 @@
         }
     ],
     "wof:id":421189811,
-    "wof:lastmodified":1566590818,
+    "wof:lastmodified":1582347611,
     "wof:name":"Bukoba",
     "wof:parent_id":1108693097,
     "wof:placetype":"locality",

--- a/data/421/189/813/421189813.geojson
+++ b/data/421/189/813/421189813.geojson
@@ -539,6 +539,9 @@
     },
     "wof:country":"TZ",
     "wof:created":1459009637,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"f3405c7f6c6bd9c4c72edc5a1fa746a0",
     "wof:hierarchy":[
         {
@@ -550,7 +553,7 @@
         }
     ],
     "wof:id":421189813,
-    "wof:lastmodified":1566590819,
+    "wof:lastmodified":1582347611,
     "wof:name":"Dar es Salaam",
     "wof:parent_id":1108692955,
     "wof:placetype":"locality",

--- a/data/421/189/817/421189817.geojson
+++ b/data/421/189/817/421189817.geojson
@@ -324,6 +324,9 @@
     },
     "wof:country":"TZ",
     "wof:created":1459009637,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"713d06309fd373a6f32b432da95c9d67",
     "wof:hierarchy":[
         {
@@ -334,7 +337,7 @@
         }
     ],
     "wof:id":421189817,
-    "wof:lastmodified":1566590819,
+    "wof:lastmodified":1582347611,
     "wof:name":"Kigoma",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/421/189/827/421189827.geojson
+++ b/data/421/189/827/421189827.geojson
@@ -326,6 +326,9 @@
     },
     "wof:country":"TZ",
     "wof:created":1459009637,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"2bb9f894b1f669548f078e0305f4dd29",
     "wof:hierarchy":[
         {
@@ -337,7 +340,7 @@
         }
     ],
     "wof:id":421189827,
-    "wof:lastmodified":1566590818,
+    "wof:lastmodified":1582347611,
     "wof:name":"Mbeya",
     "wof:parent_id":421170113,
     "wof:placetype":"locality",

--- a/data/421/190/259/421190259.geojson
+++ b/data/421/190/259/421190259.geojson
@@ -102,6 +102,9 @@
     },
     "wof:country":"TZ",
     "wof:created":1459009652,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c24829913eaa7522d4751edc116998e3",
     "wof:hierarchy":[
         {
@@ -112,7 +115,7 @@
         }
     ],
     "wof:id":421190259,
-    "wof:lastmodified":1566590827,
+    "wof:lastmodified":1582347613,
     "wof:name":"Wete",
     "wof:parent_id":85679683,
     "wof:placetype":"county",

--- a/data/421/191/173/421191173.geojson
+++ b/data/421/191/173/421191173.geojson
@@ -89,6 +89,9 @@
     },
     "wof:country":"TZ",
     "wof:created":1459009683,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a11a5971cad3036cf60f7b324d9c652f",
     "wof:hierarchy":[
         {
@@ -99,7 +102,7 @@
         }
     ],
     "wof:id":421191173,
-    "wof:lastmodified":1566590826,
+    "wof:lastmodified":1582347613,
     "wof:name":"Kati",
     "wof:parent_id":85679651,
     "wof:placetype":"county",

--- a/data/421/191/925/421191925.geojson
+++ b/data/421/191/925/421191925.geojson
@@ -107,6 +107,9 @@
     },
     "wof:country":"TZ",
     "wof:created":1459009714,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ac651bf590437bcfa0a27188dac549cd",
     "wof:hierarchy":[
         {
@@ -117,7 +120,7 @@
         }
     ],
     "wof:id":421191925,
-    "wof:lastmodified":1566590826,
+    "wof:lastmodified":1582347613,
     "wof:name":"Ilemela",
     "wof:parent_id":85679655,
     "wof:placetype":"county",

--- a/data/421/192/689/421192689.geojson
+++ b/data/421/192/689/421192689.geojson
@@ -553,6 +553,10 @@
     },
     "wof:country":"TZ",
     "wof:created":1459009745,
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"d9fd434fb9de341de11519fdbc2e5195",
     "wof:hierarchy":[
         {
@@ -564,7 +568,7 @@
         }
     ],
     "wof:id":421192689,
-    "wof:lastmodified":1566590808,
+    "wof:lastmodified":1582347608,
     "wof:name":"Dodoma",
     "wof:parent_id":421187957,
     "wof:placetype":"locality",

--- a/data/421/192/907/421192907.geojson
+++ b/data/421/192/907/421192907.geojson
@@ -105,6 +105,9 @@
     },
     "wof:country":"TZ",
     "wof:created":1459009753,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"656d761bf722ecac4d8c118a619f27bb",
     "wof:hierarchy":[
         {
@@ -115,7 +118,7 @@
         }
     ],
     "wof:id":421192907,
-    "wof:lastmodified":1566590807,
+    "wof:lastmodified":1582347608,
     "wof:name":"Kisarawe",
     "wof:parent_id":85679691,
     "wof:placetype":"county",

--- a/data/421/192/909/421192909.geojson
+++ b/data/421/192/909/421192909.geojson
@@ -104,6 +104,9 @@
     },
     "wof:country":"TZ",
     "wof:created":1459009753,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c8d5505c64d1669fb7ad69e320a50572",
     "wof:hierarchy":[
         {
@@ -114,7 +117,7 @@
         }
     ],
     "wof:id":421192909,
-    "wof:lastmodified":1566590806,
+    "wof:lastmodified":1582347607,
     "wof:name":"Kyela",
     "wof:parent_id":85679641,
     "wof:placetype":"county",

--- a/data/421/193/165/421193165.geojson
+++ b/data/421/193/165/421193165.geojson
@@ -104,6 +104,9 @@
     },
     "wof:country":"TZ",
     "wof:created":1459009762,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"fb9f2921d9bd0049d0d5de623dff72f5",
     "wof:hierarchy":[
         {
@@ -114,7 +117,7 @@
         }
     ],
     "wof:id":421193165,
-    "wof:lastmodified":1566590808,
+    "wof:lastmodified":1582347608,
     "wof:name":"Morogoro",
     "wof:parent_id":85679677,
     "wof:placetype":"county",

--- a/data/421/194/823/421194823.geojson
+++ b/data/421/194/823/421194823.geojson
@@ -90,6 +90,9 @@
     },
     "wof:country":"TZ",
     "wof:created":1459009820,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"9d619523fc91f2493af9e4ed5b8ba48d",
     "wof:hierarchy":[
         {
@@ -100,7 +103,7 @@
         }
     ],
     "wof:id":421194823,
-    "wof:lastmodified":1566590808,
+    "wof:lastmodified":1582347608,
     "wof:name":"Kaskazini B",
     "wof:parent_id":85679695,
     "wof:placetype":"county",

--- a/data/421/198/067/421198067.geojson
+++ b/data/421/198/067/421198067.geojson
@@ -98,6 +98,9 @@
     },
     "wof:country":"TZ",
     "wof:created":1459009935,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7cf3f05f4d78d06d65c7966074bd653f",
     "wof:hierarchy":[
         {
@@ -108,7 +111,7 @@
         }
     ],
     "wof:id":421198067,
-    "wof:lastmodified":1566590824,
+    "wof:lastmodified":1582347613,
     "wof:name":"Micheweni",
     "wof:parent_id":85679683,
     "wof:placetype":"county",

--- a/data/421/198/449/421198449.geojson
+++ b/data/421/198/449/421198449.geojson
@@ -90,6 +90,9 @@
     },
     "wof:country":"TZ",
     "wof:created":1459009948,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"0f996341c9d74aeecab7d5ef5172effb",
     "wof:hierarchy":[
         {
@@ -100,7 +103,7 @@
         }
     ],
     "wof:id":421198449,
-    "wof:lastmodified":1566590823,
+    "wof:lastmodified":1582347612,
     "wof:name":"Iringa Urban",
     "wof:parent_id":85679711,
     "wof:placetype":"county",

--- a/data/421/198/913/421198913.geojson
+++ b/data/421/198/913/421198913.geojson
@@ -123,6 +123,9 @@
     },
     "wof:country":"TZ",
     "wof:created":1459009965,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"91731eb654857c3e9db9ef5330b552c7",
     "wof:hierarchy":[
         {
@@ -133,7 +136,7 @@
         }
     ],
     "wof:id":421198913,
-    "wof:lastmodified":1566590824,
+    "wof:lastmodified":1582347612,
     "wof:name":"Temeke",
     "wof:parent_id":85679675,
     "wof:placetype":"county",

--- a/data/421/202/045/421202045.geojson
+++ b/data/421/202/045/421202045.geojson
@@ -89,6 +89,9 @@
     },
     "wof:country":"TZ",
     "wof:created":1459010102,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2f31c11b713f9f4de6597dd0f1bf28fe",
     "wof:hierarchy":[
         {
@@ -99,7 +102,7 @@
         }
     ],
     "wof:id":421202045,
-    "wof:lastmodified":1566590813,
+    "wof:lastmodified":1582347609,
     "wof:name":"Magharibi",
     "wof:parent_id":85679699,
     "wof:placetype":"county",

--- a/data/421/202/229/421202229.geojson
+++ b/data/421/202/229/421202229.geojson
@@ -90,6 +90,9 @@
     },
     "wof:country":"TZ",
     "wof:created":1459010109,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"728341095811a192d4a4097e5807f349",
     "wof:hierarchy":[
         {
@@ -100,7 +103,7 @@
         }
     ],
     "wof:id":421202229,
-    "wof:lastmodified":1566590812,
+    "wof:lastmodified":1582347609,
     "wof:name":"Kinondoni",
     "wof:parent_id":85679675,
     "wof:placetype":"county",

--- a/data/421/202/555/421202555.geojson
+++ b/data/421/202/555/421202555.geojson
@@ -114,6 +114,9 @@
     },
     "wof:country":"TZ",
     "wof:created":1459010122,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"feffa9d2a212d900bc79efcf45825ce3",
     "wof:hierarchy":[
         {
@@ -124,7 +127,7 @@
         }
     ],
     "wof:id":421202555,
-    "wof:lastmodified":1566590812,
+    "wof:lastmodified":1582347609,
     "wof:name":"Hai",
     "wof:parent_id":85679737,
     "wof:placetype":"county",

--- a/data/421/203/227/421203227.geojson
+++ b/data/421/203/227/421203227.geojson
@@ -107,6 +107,9 @@
     },
     "wof:country":"TZ",
     "wof:created":1459010144,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e0460761c94332c81f73517cb2d6491e",
     "wof:hierarchy":[
         {
@@ -117,7 +120,7 @@
         }
     ],
     "wof:id":421203227,
-    "wof:lastmodified":1566590811,
+    "wof:lastmodified":1582347609,
     "wof:name":"Mwanga",
     "wof:parent_id":85679737,
     "wof:placetype":"county",

--- a/data/421/203/229/421203229.geojson
+++ b/data/421/203/229/421203229.geojson
@@ -98,6 +98,9 @@
     },
     "wof:country":"TZ",
     "wof:created":1459010144,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"39ad44d53b36c86a79ffeebce5a2980f",
     "wof:hierarchy":[
         {
@@ -108,7 +111,7 @@
         }
     ],
     "wof:id":421203229,
-    "wof:lastmodified":1566590811,
+    "wof:lastmodified":1582347608,
     "wof:name":"Pangani",
     "wof:parent_id":85679747,
     "wof:placetype":"county",

--- a/data/421/204/027/421204027.geojson
+++ b/data/421/204/027/421204027.geojson
@@ -110,6 +110,9 @@
     },
     "wof:country":"TZ",
     "wof:created":1459010171,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"77d103a80059ad5ebc24723b82200a6f",
     "wof:hierarchy":[
         {
@@ -120,7 +123,7 @@
         }
     ],
     "wof:id":421204027,
-    "wof:lastmodified":1566590810,
+    "wof:lastmodified":1582347608,
     "wof:name":"Kilosa",
     "wof:parent_id":85679677,
     "wof:placetype":"county",

--- a/data/856/322/27/85632227.geojson
+++ b/data/856/322/27/85632227.geojson
@@ -971,6 +971,11 @@
     },
     "wof:country":"TZ",
     "wof:country_alpha3":"TZA",
+    "wof:geom_alt":[
+        "naturalearth",
+        "naturalearth-display-terrestrial-zoom6",
+        "meso"
+    ],
     "wof:geomhash":"5466bba4e36250e4f7008bd2a3ac1ab2",
     "wof:hierarchy":[
         {
@@ -987,7 +992,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1566590403,
+    "wof:lastmodified":1582347595,
     "wof:name":"Tanzania",
     "wof:parent_id":102191573,
     "wof:placetype":"country",

--- a/data/856/796/41/85679641.geojson
+++ b/data/856/796/41/85679641.geojson
@@ -295,6 +295,9 @@
         "wk:page":"Mbeya Region"
     },
     "wof:country":"TZ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"bffd89f059bebd8a1bfe8a01f32b0878",
     "wof:hierarchy":[
         {
@@ -312,7 +315,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1566590399,
+    "wof:lastmodified":1582347593,
     "wof:name":"Mbeya",
     "wof:parent_id":85632227,
     "wof:placetype":"region",

--- a/data/856/796/45/85679645.geojson
+++ b/data/856/796/45/85679645.geojson
@@ -290,6 +290,9 @@
         "wk:page":"Rukwa Region"
     },
     "wof:country":"TZ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d23efe424f7e54c86ad60caae1d45db0",
     "wof:hierarchy":[
         {
@@ -307,7 +310,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1566590383,
+    "wof:lastmodified":1582347584,
     "wof:name":"Rukwa",
     "wof:parent_id":85632227,
     "wof:placetype":"region",

--- a/data/856/796/51/85679651.geojson
+++ b/data/856/796/51/85679651.geojson
@@ -239,6 +239,9 @@
         "wd:id":"Q643120"
     },
     "wof:country":"TZ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"9266d35ab778a855736c0ccf468a7a3e",
     "wof:hierarchy":[
         {
@@ -256,7 +259,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1566590383,
+    "wof:lastmodified":1582347584,
     "wof:name":"Zanzibar South and Central",
     "wof:parent_id":85632227,
     "wof:placetype":"region",

--- a/data/856/796/55/85679655.geojson
+++ b/data/856/796/55/85679655.geojson
@@ -301,6 +301,9 @@
         "wk:page":"Mwanza Region"
     },
     "wof:country":"TZ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b02bb8a2d98aabd76ff489be810192b0",
     "wof:hierarchy":[
         {
@@ -318,7 +321,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1566590396,
+    "wof:lastmodified":1582347591,
     "wof:name":"Mwanza",
     "wof:parent_id":85632227,
     "wof:placetype":"region",

--- a/data/856/796/57/85679657.geojson
+++ b/data/856/796/57/85679657.geojson
@@ -290,6 +290,9 @@
         "wk:page":"Shinyanga Region"
     },
     "wof:country":"TZ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"543ef432a66b8cbe5e428f03cce2fb9b",
     "wof:hierarchy":[
         {
@@ -307,7 +310,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1566590381,
+    "wof:lastmodified":1582347583,
     "wof:name":"Shinyanga",
     "wof:parent_id":85632227,
     "wof:placetype":"region",

--- a/data/856/796/61/85679661.geojson
+++ b/data/856/796/61/85679661.geojson
@@ -292,6 +292,9 @@
         "wk:page":"Tabora Region"
     },
     "wof:country":"TZ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"9ab5a3a6af3e52a4965f9fe0b6bd83f3",
     "wof:hierarchy":[
         {
@@ -309,7 +312,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1566590380,
+    "wof:lastmodified":1582347583,
     "wof:name":"Tabora",
     "wof:parent_id":85632227,
     "wof:placetype":"region",

--- a/data/856/796/65/85679665.geojson
+++ b/data/856/796/65/85679665.geojson
@@ -293,6 +293,9 @@
         "wk:page":"Kagera Region"
     },
     "wof:country":"TZ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"fec3a1e8a742095749027cbeae75f4e7",
     "wof:hierarchy":[
         {
@@ -310,7 +313,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1566590394,
+    "wof:lastmodified":1582347590,
     "wof:name":"Kagera",
     "wof:parent_id":85632227,
     "wof:placetype":"region",

--- a/data/856/796/69/85679669.geojson
+++ b/data/856/796/69/85679669.geojson
@@ -301,6 +301,9 @@
         "wk:page":"Kigoma Region"
     },
     "wof:country":"TZ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"55406e875a7dd5fc0be39b3c2d2a8657",
     "wof:hierarchy":[
         {
@@ -318,7 +321,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1566590382,
+    "wof:lastmodified":1582347583,
     "wof:name":"Kigoma",
     "wof:parent_id":85632227,
     "wof:placetype":"region",

--- a/data/856/796/75/85679675.geojson
+++ b/data/856/796/75/85679675.geojson
@@ -293,6 +293,9 @@
         "wk:page":"Dar es Salaam Region"
     },
     "wof:country":"TZ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e0c24b3ba8a1e7ac6e83c7bb942f0d2d",
     "wof:hierarchy":[
         {
@@ -310,7 +313,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1566590387,
+    "wof:lastmodified":1582347586,
     "wof:name":"Dar-es-Salaam",
     "wof:parent_id":85632227,
     "wof:placetype":"region",

--- a/data/856/796/77/85679677.geojson
+++ b/data/856/796/77/85679677.geojson
@@ -298,6 +298,9 @@
         "wk:page":"Morogoro Region"
     },
     "wof:country":"TZ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a021d4ab35b14f922813c9a883d3764a",
     "wof:hierarchy":[
         {
@@ -315,7 +318,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1566590401,
+    "wof:lastmodified":1582347594,
     "wof:name":"Morogoro",
     "wof:parent_id":85632227,
     "wof:placetype":"region",

--- a/data/856/796/83/85679683.geojson
+++ b/data/856/796/83/85679683.geojson
@@ -294,6 +294,9 @@
         "wk:page":"Pemba North Region"
     },
     "wof:country":"TZ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3a43d7ad17f9b8ca86e25ed12ba3251f",
     "wof:hierarchy":[
         {
@@ -311,7 +314,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1566590400,
+    "wof:lastmodified":1582347593,
     "wof:name":"Kaskazini-Pemba",
     "wof:parent_id":85632227,
     "wof:placetype":"region",

--- a/data/856/796/87/85679687.geojson
+++ b/data/856/796/87/85679687.geojson
@@ -291,6 +291,9 @@
         "wk:page":"Pemba South Region"
     },
     "wof:country":"TZ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b25950fab0dee87836f1b94ea7b21e3b",
     "wof:hierarchy":[
         {
@@ -308,7 +311,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1566590384,
+    "wof:lastmodified":1582347585,
     "wof:name":"Kusini-Pemba",
     "wof:parent_id":85632227,
     "wof:placetype":"region",

--- a/data/856/796/91/85679691.geojson
+++ b/data/856/796/91/85679691.geojson
@@ -297,6 +297,9 @@
         "wk:page":"Pwani Region"
     },
     "wof:country":"TZ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"551ee7d391fa37653617e0b264b78071",
     "wof:hierarchy":[
         {
@@ -314,7 +317,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1566590389,
+    "wof:lastmodified":1582347587,
     "wof:name":"Pwani",
     "wof:parent_id":85632227,
     "wof:placetype":"region",

--- a/data/856/796/95/85679695.geojson
+++ b/data/856/796/95/85679695.geojson
@@ -290,6 +290,9 @@
         "wk:page":"Unguja North Region"
     },
     "wof:country":"TZ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"756f5df1c633cb211858d1d13e33af8f",
     "wof:hierarchy":[
         {
@@ -307,7 +310,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1566590381,
+    "wof:lastmodified":1582347583,
     "wof:name":"Kaskazini-Unguja",
     "wof:parent_id":85632227,
     "wof:placetype":"region",

--- a/data/856/796/99/85679699.geojson
+++ b/data/856/796/99/85679699.geojson
@@ -300,6 +300,9 @@
         "wd:id":"Q180822"
     },
     "wof:country":"TZ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"580844bc1ca672fea8280f13e86e1a2f",
     "wof:hierarchy":[
         {
@@ -317,7 +320,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1566590396,
+    "wof:lastmodified":1582347590,
     "wof:name":"Zanzibar West",
     "wof:parent_id":85632227,
     "wof:placetype":"region",

--- a/data/856/797/05/85679705.geojson
+++ b/data/856/797/05/85679705.geojson
@@ -265,6 +265,9 @@
         "wk:page":"Dodoma Region"
     },
     "wof:country":"TZ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"6386ce49909ebb29fc7c63ff00e0cfc9",
     "wof:hierarchy":[
         {
@@ -282,7 +285,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1566590372,
+    "wof:lastmodified":1582347578,
     "wof:name":"Dodoma",
     "wof:parent_id":85632227,
     "wof:placetype":"region",

--- a/data/856/797/11/85679711.geojson
+++ b/data/856/797/11/85679711.geojson
@@ -296,6 +296,9 @@
         "wk:page":"Iringa Region"
     },
     "wof:country":"TZ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"20bddef22be3e98abe18abc80212298e",
     "wof:hierarchy":[
         {
@@ -313,7 +316,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1566590373,
+    "wof:lastmodified":1582347578,
     "wof:name":"Iringa",
     "wof:parent_id":85632227,
     "wof:placetype":"region",

--- a/data/856/797/13/85679713.geojson
+++ b/data/856/797/13/85679713.geojson
@@ -298,6 +298,9 @@
         "wk:page":"Lindi Region"
     },
     "wof:country":"TZ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"0190f8849dc7215314d99bef328a0392",
     "wof:hierarchy":[
         {
@@ -315,7 +318,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1566590379,
+    "wof:lastmodified":1582347581,
     "wof:name":"Lindi",
     "wof:parent_id":85632227,
     "wof:placetype":"region",

--- a/data/856/797/17/85679717.geojson
+++ b/data/856/797/17/85679717.geojson
@@ -295,6 +295,9 @@
         "wk:page":"Mtwara Region"
     },
     "wof:country":"TZ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"66af9ba853cfab2a4769950757e175d6",
     "wof:hierarchy":[
         {
@@ -312,7 +315,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1566590373,
+    "wof:lastmodified":1582347578,
     "wof:name":"Mtwara",
     "wof:parent_id":85632227,
     "wof:placetype":"region",

--- a/data/856/797/23/85679723.geojson
+++ b/data/856/797/23/85679723.geojson
@@ -295,6 +295,9 @@
         "wk:page":"Ruvuma Region"
     },
     "wof:country":"TZ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2ee4470a7cad6c2d729d0a623fcae997",
     "wof:hierarchy":[
         {
@@ -312,7 +315,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1566590378,
+    "wof:lastmodified":1582347581,
     "wof:name":"Ruvuma",
     "wof:parent_id":85632227,
     "wof:placetype":"region",

--- a/data/856/797/27/85679727.geojson
+++ b/data/856/797/27/85679727.geojson
@@ -289,6 +289,9 @@
         "wk:page":"Singida Region"
     },
     "wof:country":"TZ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"aa8124b3a9d178ce7b6399406196ea3e",
     "wof:hierarchy":[
         {
@@ -306,7 +309,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1566590372,
+    "wof:lastmodified":1582347578,
     "wof:name":"Singida",
     "wof:parent_id":85632227,
     "wof:placetype":"region",

--- a/data/856/797/31/85679731.geojson
+++ b/data/856/797/31/85679731.geojson
@@ -304,6 +304,9 @@
         "wk:page":"Arusha Region"
     },
     "wof:country":"TZ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"4c84be27fd86dd7ea8f6666634c90de1",
     "wof:hierarchy":[
         {
@@ -321,7 +324,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1566590375,
+    "wof:lastmodified":1582347579,
     "wof:name":"Arusha",
     "wof:parent_id":85632227,
     "wof:placetype":"region",

--- a/data/856/797/33/85679733.geojson
+++ b/data/856/797/33/85679733.geojson
@@ -292,6 +292,9 @@
         "wk:page":"Manyara Region"
     },
     "wof:country":"TZ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7654df1ecd5499edfdd646b1a22cad96",
     "wof:hierarchy":[
         {
@@ -309,7 +312,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1566590371,
+    "wof:lastmodified":1582347577,
     "wof:name":"Manyara",
     "wof:parent_id":85632227,
     "wof:placetype":"region",

--- a/data/856/797/37/85679737.geojson
+++ b/data/856/797/37/85679737.geojson
@@ -296,6 +296,9 @@
         "wk:page":"Kilimanjaro Region"
     },
     "wof:country":"TZ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"8c53e300edd61d02f039dfbd2fc22167",
     "wof:hierarchy":[
         {
@@ -313,7 +316,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1566590376,
+    "wof:lastmodified":1582347580,
     "wof:name":"Kilimanjaro",
     "wof:parent_id":85632227,
     "wof:placetype":"region",

--- a/data/856/797/43/85679743.geojson
+++ b/data/856/797/43/85679743.geojson
@@ -295,6 +295,9 @@
         "wk:page":"Mara Region"
     },
     "wof:country":"TZ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"81d06bcf381c63d9b9c4df2653dd8c18",
     "wof:hierarchy":[
         {
@@ -312,7 +315,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1566590374,
+    "wof:lastmodified":1582347579,
     "wof:name":"Mara",
     "wof:parent_id":85632227,
     "wof:placetype":"region",

--- a/data/856/797/47/85679747.geojson
+++ b/data/856/797/47/85679747.geojson
@@ -295,6 +295,9 @@
         "wk:page":"Tanga Region"
     },
     "wof:country":"TZ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"55b0ea4685d70ba7db67ae71bb855f49",
     "wof:hierarchy":[
         {
@@ -312,7 +315,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1566590378,
+    "wof:lastmodified":1582347581,
     "wof:name":"Tanga",
     "wof:parent_id":85632227,
     "wof:placetype":"region",

--- a/data/856/797/51/85679751.geojson
+++ b/data/856/797/51/85679751.geojson
@@ -290,6 +290,9 @@
         "wd:id":"Q153329"
     },
     "wof:country":"TZ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f648592d0c8a7545aa53b6670a550a05",
     "wof:hierarchy":[
         {
@@ -307,7 +310,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1566590370,
+    "wof:lastmodified":1582347577,
     "wof:name":"Katavi",
     "wof:parent_id":85632227,
     "wof:placetype":"region",

--- a/data/856/797/55/85679755.geojson
+++ b/data/856/797/55/85679755.geojson
@@ -287,6 +287,9 @@
         "wd:id":"Q153339"
     },
     "wof:country":"TZ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"77e164a86c3bdab506e1f4036672f918",
     "wof:hierarchy":[
         {
@@ -304,7 +307,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1566590377,
+    "wof:lastmodified":1582347580,
     "wof:name":"Simiyu",
     "wof:parent_id":85632227,
     "wof:placetype":"region",

--- a/data/856/797/61/85679761.geojson
+++ b/data/856/797/61/85679761.geojson
@@ -190,6 +190,9 @@
         "wd:id":"Q4622385"
     },
     "wof:country":"TZ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"86aa5e04f8402eae5c7676a486799eca",
     "wof:hierarchy":[
         {
@@ -207,7 +210,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1566590369,
+    "wof:lastmodified":1582347576,
     "wof:name":"Geita",
     "wof:parent_id":85632227,
     "wof:placetype":"region",

--- a/data/856/797/65/85679765.geojson
+++ b/data/856/797/65/85679765.geojson
@@ -162,6 +162,9 @@
         "wd:id":"Q24283486"
     },
     "wof:country":"TZ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e96ed45a6d709604d2f709a1efc083ae",
     "wof:hierarchy":[
         {
@@ -179,7 +182,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1566590376,
+    "wof:lastmodified":1582347580,
     "wof:name":"Njombe",
     "wof:parent_id":85632227,
     "wof:placetype":"region",

--- a/data/857/718/79/85771879.geojson
+++ b/data/857/718/79/85771879.geojson
@@ -105,6 +105,9 @@
         "qs_pg:id":1168094
     },
     "wof:country":"TZ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e94142cc9f79670463cfb0401d679e70",
     "wof:hierarchy":[
         {
@@ -120,7 +123,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566590368,
+    "wof:lastmodified":1582347575,
     "wof:name":"Ilala",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/718/83/85771883.geojson
+++ b/data/857/718/83/85771883.geojson
@@ -98,6 +98,9 @@
         "qs_pg:id":241143
     },
     "wof:country":"TZ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"26c241d29b0fd376990b65ad8a193e9c",
     "wof:hierarchy":[
         {
@@ -113,7 +116,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566590369,
+    "wof:lastmodified":1582347575,
     "wof:name":"Keko Chini",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/718/85/85771885.geojson
+++ b/data/857/718/85/85771885.geojson
@@ -81,6 +81,9 @@
         "wk:page":"Kinondoni District"
     },
     "wof:country":"TZ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b44c5f6dba0bc62b74b210ab42f9de45",
     "wof:hierarchy":[
         {
@@ -96,7 +99,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1534379470,
+    "wof:lastmodified":1582347575,
     "wof:name":"Kinondoni",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/718/87/85771887.geojson
+++ b/data/857/718/87/85771887.geojson
@@ -72,6 +72,9 @@
         "qs_pg:id":58927
     },
     "wof:country":"TZ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c64088b4c3061d41c9d1bb1a4d33c8ba",
     "wof:hierarchy":[
         {
@@ -87,7 +90,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566590368,
+    "wof:lastmodified":1582347574,
     "wof:name":"Mgulani",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/718/89/85771889.geojson
+++ b/data/857/718/89/85771889.geojson
@@ -91,6 +91,9 @@
         "qs:id":983987
     },
     "wof:country":"TZ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ae1075b9506b31fd65e48dab4453c6d5",
     "wof:hierarchy":[
         {
@@ -106,7 +109,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1534379470,
+    "wof:lastmodified":1582347574,
     "wof:name":"Oyster Bay",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/718/91/85771891.geojson
+++ b/data/857/718/91/85771891.geojson
@@ -117,6 +117,9 @@
         "qs_pg:id":238643
     },
     "wof:country":"TZ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b81d89f6a617d69bd1ec4021b5559f73",
     "wof:hierarchy":[
         {
@@ -132,7 +135,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566590368,
+    "wof:lastmodified":1582347575,
     "wof:name":"Sea View",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/718/93/85771893.geojson
+++ b/data/857/718/93/85771893.geojson
@@ -72,6 +72,9 @@
         "qs_pg:id":316927
     },
     "wof:country":"TZ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"57add2675d9d53095c673605f6094079",
     "wof:hierarchy":[
         {
@@ -87,7 +90,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566590368,
+    "wof:lastmodified":1582347574,
     "wof:name":"Temeke",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/890/451/535/890451535.geojson
+++ b/data/890/451/535/890451535.geojson
@@ -84,6 +84,9 @@
     },
     "wof:country":"TZ",
     "wof:created":1469052783,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"6b2dc2af11e052c8e2454f50a9a1b6ab",
     "wof:hierarchy":[
         {
@@ -94,7 +97,7 @@
         }
     ],
     "wof:id":890451535,
-    "wof:lastmodified":1566590845,
+    "wof:lastmodified":1582347618,
     "wof:name":"Kaskazini A",
     "wof:parent_id":85679695,
     "wof:placetype":"county",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.