### PR TITLE
Name updates

### DIFF
--- a/data/421/189/813/421189813.geojson
+++ b/data/421/189/813/421189813.geojson
@@ -32,8 +32,14 @@
     "name:arg_x_preferred":[
         "Dar es Salaam"
     ],
+    "name:arz_x_preferred":[
+        "\u062f\u0627\u0631\u0627\u0644\u0633\u0644\u0627\u0645"
+    ],
     "name:ast_x_preferred":[
         "Dar es-Salam"
+    ],
+    "name:ast_x_variant":[
+        "Dar es Salaam"
     ],
     "name:azb_x_preferred":[
         "\u062f\u0627\u0631\u0627\u0644\u0633\u0644\u0627\u0645"
@@ -83,6 +89,9 @@
     "name:dan_x_preferred":[
         "Dar es-Salaam"
     ],
+    "name:deu_ch_x_preferred":[
+        "Daressalam"
+    ],
     "name:deu_x_preferred":[
         "Daressalam"
     ],
@@ -91,6 +100,12 @@
     ],
     "name:ell_x_variant":[
         "\u039d\u03c4\u03b1\u03c1 \u03b5\u03c2 \u03a3\u03b1\u03bb\u03ac\u03bc"
+    ],
+    "name:eng_ca_x_preferred":[
+        "Dar es Salaam"
+    ],
+    "name:eng_gb_x_preferred":[
+        "Dar es Salaam"
     ],
     "name:eng_x_preferred":[
         "Dar es Salaam"
@@ -154,6 +169,9 @@
     ],
     "name:hun_x_preferred":[
         "Dar es-Salaam"
+    ],
+    "name:ido_x_preferred":[
+        "Dar-es-Salaam"
     ],
     "name:ile_x_preferred":[
         "Daressalaam"
@@ -278,6 +296,9 @@
     "name:pol_x_variant":[
         "Dar es Salaam"
     ],
+    "name:por_br_x_preferred":[
+        "Dar es Salaam"
+    ],
     "name:por_x_preferred":[
         "Dar es Salaam"
     ],
@@ -347,6 +368,9 @@
     "name:tgl_x_preferred":[
         "Lungsod ng Dar es Salaam"
     ],
+    "name:tgl_x_variant":[
+        "Dar es Salaam"
+    ],
     "name:tha_x_preferred":[
         "\u0e14\u0e32\u0e23\u0e4c-\u0e40\u0e2d\u0e2a-\u0e0b\u0e32\u0e25\u0e32\u0e21"
     ],
@@ -398,8 +422,20 @@
     "name:yue_x_preferred":[
         "\u4e09\u862d\u6e2f"
     ],
+    "name:zho_cn_x_preferred":[
+        "\u4e09\u5170\u6e2f"
+    ],
+    "name:zho_hk_x_preferred":[
+        "\u4e09\u862d\u6e2f"
+    ],
+    "name:zho_tw_x_preferred":[
+        "\u4e09\u862d\u6e2f"
+    ],
     "name:zho_x_preferred":[
         "\u8fbe\u7d2f\u65af\u8428\u62c9\u59c6"
+    ],
+    "name:zho_x_variant":[
+        "\u4e09\u862d\u6e2f"
     ],
     "ne:ADM0CAP":1.0,
     "ne:ADM0NAME":"Tanzania",
@@ -524,8 +560,8 @@
     "wof:belongsto":[
         102191573,
         85632227,
-        85679675,
-        1108692955
+        1108692955,
+        85679675
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -553,7 +589,7 @@
         }
     ],
     "wof:id":421189813,
-    "wof:lastmodified":1582347611,
+    "wof:lastmodified":1587428348,
     "wof:name":"Dar es Salaam",
     "wof:parent_id":1108692955,
     "wof:placetype":"locality",

--- a/data/856/322/27/85632227.geojson
+++ b/data/856/322/27/85632227.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":76.909661,
-    "geom:area_square_m":944304049915.656006,
+    "geom:area_square_m":944304047985.476074,
     "geom:bbox":"29.34,-11.761254,40.445446,-0.984406",
     "geom:latitude":-6.263311,
     "geom:longitude":34.8204,
@@ -58,6 +58,9 @@
     "name:arg_x_preferred":[
         "Tanzania"
     ],
+    "name:ary_x_preferred":[
+        "\u0637\u0627\u0646\u0632\u0627\u0646\u064a\u0627"
+    ],
     "name:arz_x_preferred":[
         "\u062a\u0627\u0646\u0632\u0627\u0646\u064a\u0627"
     ],
@@ -66,6 +69,9 @@
     ],
     "name:ast_x_variant":[
         "Tanzania"
+    ],
+    "name:aym_x_preferred":[
+        "Tansanya"
     ],
     "name:azb_x_preferred":[
         "\u062a\u0627\u0646\u0632\u0627\u0646\u06cc\u0627"
@@ -81,6 +87,9 @@
     ],
     "name:bam_x_variant":[
         "Tanzani"
+    ],
+    "name:ban_x_preferred":[
+        "Tanzania"
     ],
     "name:bcl_x_preferred":[
         "Tansaniya"
@@ -173,11 +182,20 @@
     "name:dan_x_preferred":[
         "Tanzania"
     ],
+    "name:deu_at_x_preferred":[
+        "Tansania"
+    ],
+    "name:deu_ch_x_preferred":[
+        "Tansania"
+    ],
     "name:deu_x_preferred":[
         "Tansania"
     ],
     "name:deu_x_variant":[
         "Vereinigte Republik Tansania"
+    ],
+    "name:din_x_preferred":[
+        "Tandhania"
     ],
     "name:diq_x_preferred":[
         "Tanzanya"
@@ -193,6 +211,12 @@
     ],
     "name:ell_x_preferred":[
         "\u03a4\u03b1\u03bd\u03b6\u03b1\u03bd\u03af\u03b1"
+    ],
+    "name:eng_ca_x_preferred":[
+        "Tanzania"
+    ],
+    "name:eng_gb_x_preferred":[
+        "Tanzania"
     ],
     "name:eng_x_preferred":[
         "Tanzania"
@@ -259,6 +283,9 @@
     ],
     "name:gag_x_preferred":[
         "Tanzaniya"
+    ],
+    "name:gcr_x_preferred":[
+        "Tanzani"
     ],
     "name:gla_x_preferred":[
         "Tansainia"
@@ -517,6 +544,9 @@
     "name:mya_x_variant":[
         "\u1010\u1014\u103a\u1007\u1014\u103a\u1014\u102e\u1038\u101a\u102c\u1038"
     ],
+    "name:myv_x_preferred":[
+        "\u0422\u0430\u043d\u0437\u0430\u043d\u0438\u044f"
+    ],
     "name:mzn_x_preferred":[
         "\u062a\u0627\u0646\u0632\u0627\u0646\u06cc\u0627"
     ],
@@ -607,6 +637,9 @@
     "name:pol_x_preferred":[
         "Tanzania"
     ],
+    "name:por_br_x_preferred":[
+        "Tanz\u00e2nia"
+    ],
     "name:por_x_preferred":[
         "Tanz\u00e2nia"
     ],
@@ -668,6 +701,9 @@
     "name:sme_x_preferred":[
         "Tanz\u00e1nia"
     ],
+    "name:smo_x_preferred":[
+        "Tanzania"
+    ],
     "name:sna_x_preferred":[
         "Tanzania"
     ],
@@ -695,6 +731,12 @@
     "name:srd_x_preferred":[
         "Tanz\u00e0nia"
     ],
+    "name:srp_ec_x_preferred":[
+        "\u0422\u0430\u043d\u0437\u0430\u043d\u0438\u0458\u0430"
+    ],
+    "name:srp_el_x_preferred":[
+        "Tanzanija"
+    ],
     "name:srp_x_preferred":[
         "\u0422\u0430\u043d\u0437\u0430\u043d\u0438\u0458\u0430"
     ],
@@ -715,6 +757,9 @@
     ],
     "name:szl_x_preferred":[
         "Tanza\u0144ijo"
+    ],
+    "name:szy_x_preferred":[
+        "Tanzania"
     ],
     "name:tam_x_preferred":[
         "\u0ba4\u0ba9\u0bcd\u0b9a\u0bbe\u0ba9\u0bbf\u0baf\u0bbe"
@@ -760,6 +805,9 @@
     ],
     "name:twi_x_preferred":[
         "Tanzania"
+    ],
+    "name:udm_x_preferred":[
+        "\u0422\u0430\u043d\u0437\u0430\u043d\u0438\u044f"
     ],
     "name:uig_x_preferred":[
         "\u062a\u0627\u0646\u0632\u0627\u0646\u0649\u064a\u06d5"
@@ -823,8 +871,23 @@
     "name:yue_x_preferred":[
         "\u5766\u6851\u5c3c\u4e9e"
     ],
+    "name:zea_x_preferred":[
+        "Tanz\u00e2nia"
+    ],
+    "name:zha_x_preferred":[
+        "Tanzania"
+    ],
+    "name:zho_cn_x_preferred":[
+        "\u5766\u6851\u5c3c\u4e9a"
+    ],
+    "name:zho_hk_x_preferred":[
+        "\u5766\u6851\u5c3c\u4e9e"
+    ],
     "name:zho_min_nan_x_preferred":[
         "Tanzania"
+    ],
+    "name:zho_tw_x_preferred":[
+        "\u5766\u5c1a\u5c3c\u4e9e"
     ],
     "name:zho_x_preferred":[
         "\u5766\u6851\u5c3c\u4e9a"
@@ -993,7 +1056,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1583797445,
+    "wof:lastmodified":1587428346,
     "wof:name":"Tanzania",
     "wof:parent_id":102191573,
     "wof:placetype":"country",


### PR DESCRIPTION
Fixes https://github.com/whosonfirst-data/whosonfirst-data/issues/1796 and https://github.com/whosonfirst-data/whosonfirst-data/issues/1821.

This PR includes:
- Fixes to property values that start or end with `" "`, `\n`, or `\r`, removing those characters.
- Using a modified version of the [wiki names import script](https://github.com/whosonfirst/whosonfirst-cookbook/blob/master/scripts/crawl_to_add_wiki_names.py), adds new `name` properties

There will be ~260 similar PRs, one for each per-country repo. No PIP work require, can merge as-is.