### PR TITLE
tz concordances, placetype local, and more

### DIFF
--- a/data/110/869/288/9/1108692889.geojson
+++ b/data/110/869/288/9/1108692889.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.472143,
-    "geom:area_square_m":5818123258.272497,
+    "geom:area_square_m":5818122659.54436,
     "geom:bbox":"35.429504,-5.246704,36.345365,-4.312735",
     "geom:latitude":-4.741713,
     "geom:longitude":35.899225,
@@ -97,9 +97,10 @@
         "hasc:id":"TZ.DO.KD",
         "wd:id":"Q1327204"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TZ",
     "wof:created":1474326868,
-    "wof:geomhash":"b2b32d4f1c333fe35144bf4ed17a4518",
+    "wof:geomhash":"40b2e161a1cd4ddf508407e8f58199e2",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -109,7 +110,7 @@
         }
     ],
     "wof:id":1108692889,
-    "wof:lastmodified":1690876106,
+    "wof:lastmodified":1695886674,
     "wof:name":"Kondoa",
     "wof:parent_id":85679705,
     "wof:placetype":"county",

--- a/data/110/869/289/3/1108692893.geojson
+++ b/data/110/869/289/3/1108692893.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.609804,
-    "geom:area_square_m":7487828202.37118,
+    "geom:area_square_m":7487828256.787472,
     "geom:bbox":"35.77463,-7.377303,36.749697,-6.149329",
     "geom:latitude":-6.760554,
     "geom:longitude":36.333197,
@@ -135,9 +135,10 @@
     "wof:concordances":{
         "hasc:id":"TZ.DO.MP"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TZ",
     "wof:created":1474326870,
-    "wof:geomhash":"5ffc1d727484707ef9a7148b72eb5294",
+    "wof:geomhash":"1a1db44c86c61c13a07ba5274e19dc67",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -147,7 +148,7 @@
         }
     ],
     "wof:id":1108692893,
-    "wof:lastmodified":1636501526,
+    "wof:lastmodified":1695886781,
     "wof:name":"Mpwapwa",
     "wof:parent_id":85679705,
     "wof:placetype":"county",

--- a/data/110/869/289/5/1108692895.geojson
+++ b/data/110/869/289/5/1108692895.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.323343,
-    "geom:area_square_m":3976164201.433147,
+    "geom:area_square_m":3976165002.417744,
     "geom:bbox":"36.250799,-6.432337,36.963997,-5.516319",
     "geom:latitude":-6.014816,
     "geom:longitude":36.54622,
@@ -103,9 +103,10 @@
         "hasc:id":"TZ.DO.KG",
         "wd:id":"Q1094100"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TZ",
     "wof:created":1474326871,
-    "wof:geomhash":"3f36bd3dc375fa0c2f7c99a6f16b159d",
+    "wof:geomhash":"97100d5d78e02b7ec7fb8d54eef9d404",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -115,7 +116,7 @@
         }
     ],
     "wof:id":1108692895,
-    "wof:lastmodified":1690876105,
+    "wof:lastmodified":1695886579,
     "wof:name":"Kongwa",
     "wof:parent_id":85679705,
     "wof:placetype":"county",

--- a/data/110/869/289/7/1108692897.geojson
+++ b/data/110/869/289/7/1108692897.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.746349,
-    "geom:area_square_m":9172449499.563646,
+    "geom:area_square_m":9172449005.94486,
     "geom:bbox":"35.05273,-7.090811,36.304125,-5.372584",
     "geom:latitude":-6.311376,
     "geom:longitude":35.845734,
@@ -54,7 +54,7 @@
     "wof:concordances":{},
     "wof:country":"TZ",
     "wof:created":1474326873,
-    "wof:geomhash":"e925191bab08fa1d98b03b86724e177f",
+    "wof:geomhash":"ef9c848c3676dec5fec71047d4fab315",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -64,7 +64,7 @@
         }
     ],
     "wof:id":1108692897,
-    "wof:lastmodified":1627522858,
+    "wof:lastmodified":1695886570,
     "wof:name":"Chamwino",
     "wof:parent_id":85679705,
     "wof:placetype":"county",

--- a/data/110/869/289/9/1108692899.geojson
+++ b/data/110/869/289/9/1108692899.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.46003,
-    "geom:area_square_m":5655704097.473648,
+    "geom:area_square_m":5655703954.682038,
     "geom:bbox":"35.163814,-6.731604,35.969187,-5.6026",
     "geom:latitude":-6.134872,
     "geom:longitude":35.472197,
@@ -86,7 +86,7 @@
     },
     "wof:country":"TZ",
     "wof:created":1474326875,
-    "wof:geomhash":"c669bfa8919142c2d794d57bb116a99d",
+    "wof:geomhash":"b50846a15338605ffbaaf7f7e2f46526",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -96,7 +96,7 @@
         }
     ],
     "wof:id":1108692899,
-    "wof:lastmodified":1690876105,
+    "wof:lastmodified":1695886569,
     "wof:name":"Bahi",
     "wof:parent_id":85679705,
     "wof:placetype":"county",

--- a/data/110/869/290/1/1108692901.geojson
+++ b/data/110/869/290/1/1108692901.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.594658,
-    "geom:area_square_m":7322086302.169415,
+    "geom:area_square_m":7322087251.759594,
     "geom:bbox":"35.065388,-5.683134,36.323712,-4.856079",
     "geom:latitude":-5.258049,
     "geom:longitude":35.666767,
@@ -57,7 +57,7 @@
     "wof:concordances":{},
     "wof:country":"TZ",
     "wof:created":1474326877,
-    "wof:geomhash":"ff1d9186a3356806edea863094b1cd27",
+    "wof:geomhash":"0c0198e3cb61889d27db79436ace7101",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -67,7 +67,7 @@
         }
     ],
     "wof:id":1108692901,
-    "wof:lastmodified":1627522858,
+    "wof:lastmodified":1695886570,
     "wof:name":"Chemba",
     "wof:parent_id":85679705,
     "wof:placetype":"county",

--- a/data/110/869/290/3/1108692903.geojson
+++ b/data/110/869/290/3/1108692903.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.568162,
-    "geom:area_square_m":7012962082.3892,
+    "geom:area_square_m":7012962732.536608,
     "geom:bbox":"35.819936,-4.148158,36.649491,-2.756618",
     "geom:latitude":-3.404046,
     "geom:longitude":36.226232,
@@ -94,9 +94,10 @@
         "hasc:id":"TZ.AS.MO",
         "wd:id":"Q2220726"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TZ",
     "wof:created":1474326878,
-    "wof:geomhash":"5e8526ac0789ea39e39174678f2dc448",
+    "wof:geomhash":"110b5d54172e3b4c7a92a24ca4568ef1",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -106,7 +107,7 @@
         }
     ],
     "wof:id":1108692903,
-    "wof:lastmodified":1690876115,
+    "wof:lastmodified":1695886675,
     "wof:name":"Monduli",
     "wof:parent_id":85679731,
     "wof:placetype":"county",

--- a/data/110/869/290/5/1108692905.geojson
+++ b/data/110/869/290/5/1108692905.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.103017,
-    "geom:area_square_m":1271662067.127968,
+    "geom:area_square_m":1271661935.813805,
     "geom:bbox":"36.746798,-3.595614,37.064416,-3.05098",
     "geom:latitude":-3.334993,
     "geom:longitude":36.901088,
@@ -120,7 +120,7 @@
     "wof:concordances":{},
     "wof:country":"TZ",
     "wof:created":1474326880,
-    "wof:geomhash":"2ba6b4fb317e33d0302dbecc3086b8fb",
+    "wof:geomhash":"f57c149b1509cb1f14950265435061fb",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -130,7 +130,7 @@
         }
     ],
     "wof:id":1108692905,
-    "wof:lastmodified":1636501529,
+    "wof:lastmodified":1695886783,
     "wof:name":"Meru",
     "wof:parent_id":85679731,
     "wof:placetype":"county",

--- a/data/110/869/290/7/1108692907.geojson
+++ b/data/110/869/290/7/1108692907.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.021729,
-    "geom:area_square_m":268196360.455189,
+    "geom:area_square_m":268196525.069367,
     "geom:bbox":"36.583153,-3.555836,36.766304,-3.340424",
     "geom:latitude":-3.435543,
     "geom:longitude":36.674547,
@@ -54,7 +54,7 @@
     "wof:concordances":{},
     "wof:country":"TZ",
     "wof:created":1474326881,
-    "wof:geomhash":"d8741dcd38784b5a52fd72e0cea9cb2e",
+    "wof:geomhash":"e5696bdcec62c330470f50a2b2af17d0",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -64,7 +64,7 @@
         }
     ],
     "wof:id":1108692907,
-    "wof:lastmodified":1627522859,
+    "wof:lastmodified":1695886572,
     "wof:name":"Arusha Urban",
     "wof:parent_id":85679731,
     "wof:placetype":"county",

--- a/data/110/869/291/1/1108692911.geojson
+++ b/data/110/869/291/1/1108692911.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.65586,
-    "geom:area_square_m":8100650986.117228,
+    "geom:area_square_m":8100650542.255136,
     "geom:bbox":"35.886917,-3.141613,37.429372,-2.143339",
     "geom:latitude":-2.72095,
     "geom:longitude":36.495503,
@@ -66,7 +66,7 @@
     "wof:concordances":{},
     "wof:country":"TZ",
     "wof:created":1474326886,
-    "wof:geomhash":"8bb86dcaf03b5c2a0aa3c53b57cde8dc",
+    "wof:geomhash":"fd188f1b8dd06ced0338a1a40e07b98c",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -76,7 +76,7 @@
         }
     ],
     "wof:id":1108692911,
-    "wof:lastmodified":1627522865,
+    "wof:lastmodified":1695886581,
     "wof:name":"Longido",
     "wof:parent_id":85679731,
     "wof:placetype":"county",

--- a/data/110/869/291/3/1108692913.geojson
+++ b/data/110/869/291/3/1108692913.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.506695,
-    "geom:area_square_m":6248389713.197632,
+    "geom:area_square_m":6248390342.697858,
     "geom:bbox":"37.459497,-4.61371,38.403605,-3.792515",
     "geom:latitude":-4.216697,
     "geom:longitude":37.897885,
@@ -142,9 +142,10 @@
         "hasc:id":"TZ.KL.SA",
         "wd:id":"Q7193222"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TZ",
     "wof:created":1474326889,
-    "wof:geomhash":"ce2e4a3bbe4f91ad2da876e301033c9b",
+    "wof:geomhash":"56dd65f7da1b8f87ad5c582c4deb90d7",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -154,7 +155,7 @@
         }
     ],
     "wof:id":1108692913,
-    "wof:lastmodified":1690876114,
+    "wof:lastmodified":1695886783,
     "wof:name":"Same",
     "wof:parent_id":85679737,
     "wof:placetype":"county",

--- a/data/110/869/291/5/1108692915.geojson
+++ b/data/110/869/291/5/1108692915.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.005159,
-    "geom:area_square_m":63677545.10751,
+    "geom:area_square_m":63677601.145746,
     "geom:bbox":"37.286457,-3.38601,37.399349,-3.306616",
     "geom:latitude":-3.348019,
     "geom:longitude":37.341712,
@@ -85,9 +85,10 @@
         "hasc:id":"TZ.KL.MU",
         "wd:id":"Q6916218"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TZ",
     "wof:created":1474326892,
-    "wof:geomhash":"7b171d0f85b64c3a17c8aa4edb852d5a",
+    "wof:geomhash":"e0ffd7dd16c64437b4edba3ff134156a",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -97,7 +98,7 @@
         }
     ],
     "wof:id":1108692915,
-    "wof:lastmodified":1690876115,
+    "wof:lastmodified":1695886589,
     "wof:name":"Moshi Municipal",
     "wof:parent_id":85679737,
     "wof:placetype":"county",

--- a/data/110/869/291/7/1108692917.geojson
+++ b/data/110/869/291/7/1108692917.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.098991,
-    "geom:area_square_m":1222279731.313374,
+    "geom:area_square_m":1222279816.199205,
     "geom:bbox":"36.889585,-3.367171,37.264025,-2.849522",
     "geom:latitude":-3.071408,
     "geom:longitude":37.083537,
@@ -74,7 +74,7 @@
     },
     "wof:country":"TZ",
     "wof:created":1474326894,
-    "wof:geomhash":"5c40933a1630b524fd79b3f0f11ca995",
+    "wof:geomhash":"c2eeb4c27ce0b70b197ad1c655b5944e",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -84,7 +84,7 @@
         }
     ],
     "wof:id":1108692917,
-    "wof:lastmodified":1690876114,
+    "wof:lastmodified":1695886031,
     "wof:name":"Siha",
     "wof:parent_id":85679737,
     "wof:placetype":"county",

--- a/data/110/869/291/9/1108692919.geojson
+++ b/data/110/869/291/9/1108692919.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.261165,
-    "geom:area_square_m":3217429756.506478,
+    "geom:area_square_m":3217429233.078059,
     "geom:bbox":"37.902237,-5.370255,38.768262,-4.491565",
     "geom:latitude":-4.921609,
     "geom:longitude":38.307605,
@@ -121,9 +121,10 @@
         "hasc:id":"TZ.TN.KO",
         "wd:id":"Q6432493"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TZ",
     "wof:created":1474326896,
-    "wof:geomhash":"d1749f9a46538541704d8e87f5f7c0a6",
+    "wof:geomhash":"12f214d3f949275c2cb1f4439d603dd1",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -133,7 +134,7 @@
         }
     ],
     "wof:id":1108692919,
-    "wof:lastmodified":1690876114,
+    "wof:lastmodified":1695886783,
     "wof:name":"Korogwe",
     "wof:parent_id":85679747,
     "wof:placetype":"county",

--- a/data/110/869/292/1/1108692921.geojson
+++ b/data/110/869/292/1/1108692921.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.122179,
-    "geom:area_square_m":1504592040.246908,
+    "geom:area_square_m":1504591889.805777,
     "geom:bbox":"38.575342,-5.426086,39.072702,-4.932191",
     "geom:latitude":-5.180976,
     "geom:longitude":38.763903,
@@ -85,9 +85,10 @@
         "hasc:id":"TZ.TN.MU",
         "wd:id":"Q6933027"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TZ",
     "wof:created":1474326897,
-    "wof:geomhash":"3631f43c2925c52b9fc047ddcbb8d758",
+    "wof:geomhash":"2eca10732c2e3c5179eb810e66f6c9a4",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -97,7 +98,7 @@
         }
     ],
     "wof:id":1108692921,
-    "wof:lastmodified":1690876106,
+    "wof:lastmodified":1695886589,
     "wof:name":"Muheza",
     "wof:parent_id":85679747,
     "wof:placetype":"county",

--- a/data/110/869/292/3/1108692923.geojson
+++ b/data/110/869/292/3/1108692923.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.532886,
-    "geom:area_square_m":6558125494.062165,
+    "geom:area_square_m":6558125001.545038,
     "geom:bbox":"37.691029,-6.019738,38.734372,-4.96809",
     "geom:latitude":-5.565083,
     "geom:longitude":38.300139,
@@ -94,9 +94,10 @@
         "hasc:id":"TZ.TN.HA",
         "wd:id":"Q3299071"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TZ",
     "wof:created":1474326900,
-    "wof:geomhash":"dd25e4f2df02a470a35618218d10deab",
+    "wof:geomhash":"e53da869af9b1128a180da6881cabf0d",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -106,7 +107,7 @@
         }
     ],
     "wof:id":1108692923,
-    "wof:lastmodified":1690876106,
+    "wof:lastmodified":1695886572,
     "wof:name":"Handeni",
     "wof:parent_id":85679747,
     "wof:placetype":"county",

--- a/data/110/869/292/5/1108692925.geojson
+++ b/data/110/869/292/5/1108692925.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.525001,
-    "geom:area_square_m":6461625987.995811,
+    "geom:area_square_m":6461626738.38588,
     "geom:bbox":"37.018946,-6.000518,37.97619,-5.004935",
     "geom:latitude":-5.514496,
     "geom:longitude":37.562689,
@@ -94,9 +94,10 @@
         "hasc:id":"TZ.TN.KI",
         "wd:id":"Q1888326"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TZ",
     "wof:created":1474326902,
-    "wof:geomhash":"9f4adb914ff7e4d42f6e8da54dcad658",
+    "wof:geomhash":"6d967aa88c127826ef9f4a5ecb5a35d1",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -106,7 +107,7 @@
         }
     ],
     "wof:id":1108692925,
-    "wof:lastmodified":1690876107,
+    "wof:lastmodified":1695886578,
     "wof:name":"Kilindi",
     "wof:parent_id":85679747,
     "wof:placetype":"county",

--- a/data/110/869/292/9/1108692929.geojson
+++ b/data/110/869/292/9/1108692929.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.221059,
-    "geom:area_square_m":2724046865.398732,
+    "geom:area_square_m":2724046180.707546,
     "geom:bbox":"38.661295,-5.036694,39.220056,-4.358039",
     "geom:latitude":-4.748237,
     "geom:longitude":38.925209,
@@ -74,7 +74,7 @@
     },
     "wof:country":"TZ",
     "wof:created":1474326904,
-    "wof:geomhash":"7c7cbe41bf5233084a9f7de8d0efa68a",
+    "wof:geomhash":"d28b1f02c4abc0f5ad212c54af995c59",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -84,7 +84,7 @@
         }
     ],
     "wof:id":1108692929,
-    "wof:lastmodified":1690876106,
+    "wof:lastmodified":1695886585,
     "wof:name":"Mkinga",
     "wof:parent_id":85679747,
     "wof:placetype":"county",

--- a/data/110/869/293/1/1108692931.geojson
+++ b/data/110/869/293/1/1108692931.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.018378,
-    "geom:area_square_m":226331159.327571,
+    "geom:area_square_m":226331106.070433,
     "geom:bbox":"38.386096,-5.245489,38.564987,-5.045361",
     "geom:latitude":-5.161623,
     "geom:longitude":38.477408,
@@ -54,7 +54,7 @@
     "wof:concordances":{},
     "wof:country":"TZ",
     "wof:created":1474326905,
-    "wof:geomhash":"8d65f28dbadd4dc0f5f869738827026f",
+    "wof:geomhash":"b4ae8bb8feea4c7a0e9ec9930e9b80be",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -64,7 +64,7 @@
         }
     ],
     "wof:id":1108692931,
-    "wof:lastmodified":1627522864,
+    "wof:lastmodified":1695886580,
     "wof:name":"Korogwe Township Authority",
     "wof:parent_id":85679747,
     "wof:placetype":"county",

--- a/data/110/869/293/3/1108692933.geojson
+++ b/data/110/869/293/3/1108692933.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.068336,
-    "geom:area_square_m":841128944.670016,
+    "geom:area_square_m":841129389.795615,
     "geom:bbox":"37.695424,-5.630962,38.153112,-5.250668",
     "geom:latitude":-5.475527,
     "geom:longitude":37.967782,
@@ -55,7 +55,7 @@
     "wof:concordances":{},
     "wof:country":"TZ",
     "wof:created":1474326907,
-    "wof:geomhash":"a6e7bb276d8d308e109ec78deb51976c",
+    "wof:geomhash":"8361b7d17a0125e54ceb45ab996b74fb",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -65,7 +65,7 @@
         }
     ],
     "wof:id":1108692933,
-    "wof:lastmodified":1627522859,
+    "wof:lastmodified":1695886572,
     "wof:name":"Handeni Township Authority",
     "wof:parent_id":85679747,
     "wof:placetype":"county",

--- a/data/110/869/293/5/1108692935.geojson
+++ b/data/110/869/293/5/1108692935.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.112112,
-    "geom:area_square_m":13603619371.89617,
+    "geom:area_square_m":13603619158.039726,
     "geom:bbox":"35.323258,-9.489389,37.801057,-7.634064",
     "geom:latitude":-8.399201,
     "geom:longitude":36.558275,
@@ -94,9 +94,10 @@
         "hasc:id":"TZ.MO.KM",
         "wd:id":"Q927705"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TZ",
     "wof:created":1474326910,
-    "wof:geomhash":"a5fa01032c1efffc9612b569e2970452",
+    "wof:geomhash":"f0e8a39af8fcd65b48943a561afef75d",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -106,7 +107,7 @@
         }
     ],
     "wof:id":1108692935,
-    "wof:lastmodified":1690876108,
+    "wof:lastmodified":1695886578,
     "wof:name":"Kilombero",
     "wof:parent_id":85679677,
     "wof:placetype":"county",

--- a/data/110/869/293/7/1108692937.geojson
+++ b/data/110/869/293/7/1108692937.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.929486,
-    "geom:area_square_m":23560710720.595261,
+    "geom:area_square_m":23560710209.560863,
     "geom:bbox":"35.673306,-9.921631,37.437572,-8.164594",
     "geom:latitude":-9.052334,
     "geom:longitude":36.613334,
@@ -103,9 +103,10 @@
         "hasc:id":"TZ.MO.UL",
         "wd:id":"Q7878736"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TZ",
     "wof:created":1474326912,
-    "wof:geomhash":"1113a402da3c462f03413501b36acdae",
+    "wof:geomhash":"42acec56d59f7b9ba5a3bf5ecccca339",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -115,7 +116,7 @@
         }
     ],
     "wof:id":1108692937,
-    "wof:lastmodified":1690876108,
+    "wof:lastmodified":1695886033,
     "wof:name":"Ulanga",
     "wof:parent_id":85679677,
     "wof:placetype":"county",

--- a/data/110/869/293/9/1108692939.geojson
+++ b/data/110/869/293/9/1108692939.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.023586,
-    "geom:area_square_m":289610039.926232,
+    "geom:area_square_m":289610747.739964,
     "geom:bbox":"37.583241,-6.914719,37.7513,-6.656876",
     "geom:latitude":-6.778727,
     "geom:longitude":37.663501,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"TZ.MO.MU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TZ",
     "wof:created":1474326913,
-    "wof:geomhash":"f8bcd9c9e5b0fd7cc130118b4ad53582",
+    "wof:geomhash":"9fa4f7100b08b41bdc68ee5745dc5bb5",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1108692939,
-    "wof:lastmodified":1627522869,
+    "wof:lastmodified":1695886589,
     "wof:name":"Morogoro Urban",
     "wof:parent_id":85679677,
     "wof:placetype":"county",

--- a/data/110/869/294/1/1108692941.geojson
+++ b/data/110/869/294/1/1108692941.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.542184,
-    "geom:area_square_m":6660672510.811008,
+    "geom:area_square_m":6660672171.730926,
     "geom:bbox":"37.187902,-7.397552,38.079389,-5.800069",
     "geom:latitude":-6.519537,
     "geom:longitude":37.545176,
@@ -97,9 +97,10 @@
         "hasc:id":"TZ.MO.MV",
         "wd:id":"Q3711212"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TZ",
     "wof:created":1474326915,
-    "wof:geomhash":"b9f12a1f004aaf29963e96570b50c75c",
+    "wof:geomhash":"669e68b067824db6ddbed8815db298b9",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -109,7 +110,7 @@
         }
     ],
     "wof:id":1108692941,
-    "wof:lastmodified":1690876107,
+    "wof:lastmodified":1695886591,
     "wof:name":"Mvomero",
     "wof:parent_id":85679677,
     "wof:placetype":"county",

--- a/data/110/869/294/3/1108692943.geojson
+++ b/data/110/869/294/3/1108692943.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.161095,
-    "geom:area_square_m":1980289176.950372,
+    "geom:area_square_m":1980288807.377275,
     "geom:bbox":"36.72172,-6.596787,37.387881,-5.85829",
     "geom:latitude":-6.205805,
     "geom:longitude":37.00758,
@@ -60,7 +60,7 @@
     "wof:concordances":{},
     "wof:country":"TZ",
     "wof:created":1474326916,
-    "wof:geomhash":"601f10759690119dfef5dfcd1d540cc9",
+    "wof:geomhash":"8f12443f1b3d14ef624e36d5ba73517d",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -70,7 +70,7 @@
         }
     ],
     "wof:id":1108692943,
-    "wof:lastmodified":1627522859,
+    "wof:lastmodified":1695886572,
     "wof:name":"Gairo",
     "wof:parent_id":85679677,
     "wof:placetype":"county",

--- a/data/110/869/294/7/1108692947.geojson
+++ b/data/110/869/294/7/1108692947.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.691015,
-    "geom:area_square_m":8492680214.10262,
+    "geom:area_square_m":8492680665.499318,
     "geom:bbox":"37.798293,-6.777452,39.121064,-5.841273",
     "geom:latitude":-6.311685,
     "geom:longitude":38.409017,
@@ -159,9 +159,10 @@
     "wof:concordances":{
         "hasc:id":"TZ.PW.BA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TZ",
     "wof:created":1474326918,
-    "wof:geomhash":"30910a849709980e842044f5164c5019",
+    "wof:geomhash":"842f7f08f8469396f798d73aca74faaa",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -171,7 +172,7 @@
         }
     ],
     "wof:id":1108692947,
-    "wof:lastmodified":1636501526,
+    "wof:lastmodified":1695886782,
     "wof:name":"Bagamoyo",
     "wof:parent_id":85679691,
     "wof:placetype":"county",

--- a/data/110/869/294/9/1108692949.geojson
+++ b/data/110/869/294/9/1108692949.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.122664,
-    "geom:area_square_m":1506038738.241591,
+    "geom:area_square_m":1506038317.028179,
     "geom:bbox":"38.246153,-6.971075,38.974107,-6.640222",
     "geom:latitude":-6.819449,
     "geom:longitude":38.551521,
@@ -159,9 +159,10 @@
     "wof:concordances":{
         "hasc:id":"TZ.PW.KB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TZ",
     "wof:created":1474326919,
-    "wof:geomhash":"0dd2c88352fddf7b998c9f3697de38aa",
+    "wof:geomhash":"4f8c5bf46b413bfcb764d70d579d764a",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -171,7 +172,7 @@
         }
     ],
     "wof:id":1108692949,
-    "wof:lastmodified":1636501526,
+    "wof:lastmodified":1695886782,
     "wof:name":"Kibaha",
     "wof:parent_id":85679691,
     "wof:placetype":"county",

--- a/data/110/869/295/1/1108692951.geojson
+++ b/data/110/869/295/1/1108692951.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.052694,
-    "geom:area_square_m":645430186.642137,
+    "geom:area_square_m":645430186.641783,
     "geom:bbox":"39.503777749,-8.10384956,39.908450024,-7.616327064",
     "geom:latitude":-7.870189,
     "geom:longitude":39.754865,
@@ -276,9 +276,10 @@
     "wof:concordances":{
         "hasc:id":"TZ.PW.MA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TZ",
     "wof:created":1474326925,
-    "wof:geomhash":"8cd75a79630e7751d1db72cb9b05b535",
+    "wof:geomhash":"de9eea26cbdec3e5b9d9cdd82904587d",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -288,7 +289,7 @@
         }
     ],
     "wof:id":1108692951,
-    "wof:lastmodified":1566590679,
+    "wof:lastmodified":1695886675,
     "wof:name":"Mafia",
     "wof:parent_id":85679691,
     "wof:placetype":"county",

--- a/data/110/869/295/3/1108692953.geojson
+++ b/data/110/869/295/3/1108692953.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.057681,
-    "geom:area_square_m":708373623.101232,
+    "geom:area_square_m":708373290.307324,
     "geom:bbox":"38.754063,-6.834541,39.072388,-6.546581",
     "geom:latitude":-6.691961,
     "geom:longitude":38.9137,
@@ -54,7 +54,7 @@
     "wof:concordances":{},
     "wof:country":"TZ",
     "wof:created":1474326927,
-    "wof:geomhash":"a88e011f370774085938fa5740cac5ea",
+    "wof:geomhash":"8ff095521f316234dd87a8f5acc857b3",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -64,7 +64,7 @@
         }
     ],
     "wof:id":1108692953,
-    "wof:lastmodified":1627522862,
+    "wof:lastmodified":1695886576,
     "wof:name":"Kibaha Urban",
     "wof:parent_id":85679691,
     "wof:placetype":"county",

--- a/data/110/869/295/5/1108692955.geojson
+++ b/data/110/869/295/5/1108692955.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.029863,
-    "geom:area_square_m":366562121.980312,
+    "geom:area_square_m":366562161.436875,
     "geom:bbox":"39.021298,-7.091795,39.300186,-6.790951",
     "geom:latitude":-6.932808,
     "geom:longitude":39.149243,
@@ -75,9 +75,10 @@
     "wof:concordances":{
         "hasc:id":"TZ.DS.IL"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TZ",
     "wof:created":1474326930,
-    "wof:geomhash":"a17f4853ad6c5837d2d8faa7e0611d0d",
+    "wof:geomhash":"519b6eb9c3e10a32ef895b0408bb6eb0",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -87,7 +88,7 @@
         }
     ],
     "wof:id":1108692955,
-    "wof:lastmodified":1627522860,
+    "wof:lastmodified":1695886573,
     "wof:name":"Ilala",
     "wof:parent_id":85679675,
     "wof:placetype":"county",

--- a/data/110/869/295/7/1108692957.geojson
+++ b/data/110/869/295/7/1108692957.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.49275,
-    "geom:area_square_m":5999715870.249313,
+    "geom:area_square_m":5999715881.836228,
     "geom:bbox":"39.017755,-10.617914,39.979933,-9.456919",
     "geom:latitude":-10.032566,
     "geom:longitude":39.466797,
@@ -67,9 +67,10 @@
     "wof:concordances":{
         "hasc:id":"TZ.LI.LR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TZ",
     "wof:created":1474326934,
-    "wof:geomhash":"7f05aba440d26818e5350c9c449af1b4",
+    "wof:geomhash":"88c16e206d9a8d862f077c87187b3327",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1108692957,
-    "wof:lastmodified":1627522865,
+    "wof:lastmodified":1695886581,
     "wof:name":"Lindi Rural",
     "wof:parent_id":85679713,
     "wof:placetype":"county",

--- a/data/110/869/295/9/1108692959.geojson
+++ b/data/110/869/295/9/1108692959.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.493198,
-    "geom:area_square_m":5998645879.125887,
+    "geom:area_square_m":5998645046.911582,
     "geom:bbox":"37.509944,-10.735825,38.927832,-9.918844",
     "geom:latitude":-10.380565,
     "geom:longitude":38.362904,
@@ -97,9 +97,10 @@
         "hasc:id":"TZ.LI.NA",
         "wd:id":"Q7194478"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TZ",
     "wof:created":1474326937,
-    "wof:geomhash":"977c3a3f08316dd1fe3aad81e7ac4ba4",
+    "wof:geomhash":"6d37b072a33d28e66dc533ce5f88071a",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -109,7 +110,7 @@
         }
     ],
     "wof:id":1108692959,
-    "wof:lastmodified":1690876107,
+    "wof:lastmodified":1695886591,
     "wof:name":"Nachingwea",
     "wof:parent_id":85679713,
     "wof:placetype":"county",

--- a/data/110/869/296/1/1108692961.geojson
+++ b/data/110/869/296/1/1108692961.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.824262,
-    "geom:area_square_m":34457983257.228096,
+    "geom:area_square_m":34457983702.43811,
     "geom:bbox":"36.868123,-10.440183,38.717767,-7.932525",
     "geom:latitude":-9.334629,
     "geom:longitude":37.873636,
@@ -91,9 +91,10 @@
         "hasc:id":"TZ.LI.LI",
         "wd:id":"Q6272988"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TZ",
     "wof:created":1474326938,
-    "wof:geomhash":"4a87169491a44546e7a3d68df17d0897",
+    "wof:geomhash":"6907d8e5aadc4861d091be3738e14c26",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -103,7 +104,7 @@
         }
     ],
     "wof:id":1108692961,
-    "wof:lastmodified":1690876114,
+    "wof:lastmodified":1695886581,
     "wof:name":"Liwale",
     "wof:parent_id":85679713,
     "wof:placetype":"county",

--- a/data/110/869/296/5/1108692965.geojson
+++ b/data/110/869/296/5/1108692965.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.207471,
-    "geom:area_square_m":2526033652.892429,
+    "geom:area_square_m":2526033659.985758,
     "geom:bbox":"38.713158,-10.51211,39.194358,-9.667763",
     "geom:latitude":-10.049899,
     "geom:longitude":38.986179,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"TZ.LI.RU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TZ",
     "wof:created":1474326940,
-    "wof:geomhash":"feb98628dbefa4daf18ffeca41e29bc9",
+    "wof:geomhash":"dbd2b4a3879f25be84eb00dc13b98738",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1108692965,
-    "wof:lastmodified":1627522873,
+    "wof:lastmodified":1695886027,
     "wof:name":"Ruangwa",
     "wof:parent_id":85679713,
     "wof:placetype":"county",

--- a/data/110/869/296/7/1108692967.geojson
+++ b/data/110/869/296/7/1108692967.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.087715,
-    "geom:area_square_m":1068273849.489095,
+    "geom:area_square_m":1068274487.768038,
     "geom:bbox":"39.389159,-10.147128,39.807591,-9.77469",
     "geom:latitude":-9.95711,
     "geom:longitude":39.633411,
@@ -76,9 +76,10 @@
         "hasc:id":"TZ.LI.LU",
         "wd:id":"Q6552506"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TZ",
     "wof:created":1474326941,
-    "wof:geomhash":"063827f5cdcf815a0c2da29264edaf31",
+    "wof:geomhash":"ec0d2d272e855fd579da03674d68b5a9",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -88,7 +89,7 @@
         }
     ],
     "wof:id":1108692967,
-    "wof:lastmodified":1690876113,
+    "wof:lastmodified":1695886581,
     "wof:name":"Lindi Urban",
     "wof:parent_id":85679713,
     "wof:placetype":"county",

--- a/data/110/869/296/9/1108692969.geojson
+++ b/data/110/869/296/9/1108692969.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.304906,
-    "geom:area_square_m":3707272534.812751,
+    "geom:area_square_m":3707272544.025114,
     "geom:bbox":"39.644577,-10.82835,40.444735,-10.125081",
     "geom:latitude":-10.484051,
     "geom:longitude":40.003378,
@@ -73,9 +73,10 @@
     "wof:concordances":{
         "hasc:id":"TZ.MT.MR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TZ",
     "wof:created":1474326943,
-    "wof:geomhash":"7bff0192a1286ffb613469e6c8450f82",
+    "wof:geomhash":"c2aeac494262d8ef309a6f620684ffbe",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -85,7 +86,7 @@
         }
     ],
     "wof:id":1108692969,
-    "wof:lastmodified":1627522870,
+    "wof:lastmodified":1695886589,
     "wof:name":"Mtwara Rural",
     "wof:parent_id":85679717,
     "wof:placetype":"county",

--- a/data/110/869/297/1/1108692971.geojson
+++ b/data/110/869/297/1/1108692971.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.16138,
-    "geom:area_square_m":1960670483.976279,
+    "geom:area_square_m":1960670503.696044,
     "geom:bbox":"39.010763,-11.075818,39.511422,-10.325021",
     "geom:latitude":-10.719138,
     "geom:longitude":39.283495,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"TZ.MT.NE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TZ",
     "wof:created":1474326944,
-    "wof:geomhash":"49d43d1ef2610c0d64ba8346d5258112",
+    "wof:geomhash":"e5190e11b691d352545872ac4ee821c4",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1108692971,
-    "wof:lastmodified":1642551772,
+    "wof:lastmodified":1695886515,
     "wof:name":"Newala",
     "wof:parent_id":85679717,
     "wof:placetype":"county",

--- a/data/110/869/297/3/1108692973.geojson
+++ b/data/110/869/297/3/1108692973.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.331104,
-    "geom:area_square_m":4021596532.310194,
+    "geom:area_square_m":4021596329.476509,
     "geom:bbox":"38.264241,-11.176288,39.377769,-10.346942",
     "geom:latitude":-10.80132,
     "geom:longitude":38.895918,
@@ -163,9 +163,10 @@
         "hasc:id":"TZ.MT.MA",
         "wd:id":"Q1003089"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TZ",
     "wof:created":1474326946,
-    "wof:geomhash":"8c25d26ec71d6883bea6b41784dfaddf",
+    "wof:geomhash":"d1ecf87c85e6cd1ecad76e291e908c19",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -175,7 +176,7 @@
         }
     ],
     "wof:id":1108692973,
-    "wof:lastmodified":1690876115,
+    "wof:lastmodified":1695886783,
     "wof:name":"Masasi",
     "wof:parent_id":85679717,
     "wof:placetype":"county",

--- a/data/110/869/297/5/1108692975.geojson
+++ b/data/110/869/297/5/1108692975.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.169295,
-    "geom:area_square_m":2056843032.415511,
+    "geom:area_square_m":2056842836.712264,
     "geom:bbox":"39.322603,-10.994339,39.914462,-10.332127",
     "geom:latitude":-10.716338,
     "geom:longitude":39.566982,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"TZ.MT.TA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TZ",
     "wof:created":1474326947,
-    "wof:geomhash":"5a019cf777ac0744f62042714d0b5e27",
+    "wof:geomhash":"9d84bcac90d89680770aa01cfee803ba",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1108692975,
-    "wof:lastmodified":1627522877,
+    "wof:lastmodified":1695886032,
     "wof:name":"Tandahimba",
     "wof:parent_id":85679717,
     "wof:placetype":"county",

--- a/data/110/869/297/7/1108692977.geojson
+++ b/data/110/869/297/7/1108692977.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.014024,
-    "geom:area_square_m":170602386.78582,
+    "geom:area_square_m":170602069.885852,
     "geom:bbox":"40.059441,-10.381024,40.236439,-10.251823",
     "geom:latitude":-10.313108,
     "geom:longitude":40.153351,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"TZ.MT.MU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TZ",
     "wof:created":1474326949,
-    "wof:geomhash":"d889f7d6446eb81ac41456ffc79bbf02",
+    "wof:geomhash":"a9343636f92d1bee7e31423182bd6983",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1108692977,
-    "wof:lastmodified":1627522870,
+    "wof:lastmodified":1695886590,
     "wof:name":"Mtwara Urban",
     "wof:parent_id":85679717,
     "wof:placetype":"county",

--- a/data/110/869/297/9/1108692979.geojson
+++ b/data/110/869/297/9/1108692979.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.430477,
-    "geom:area_square_m":5224590063.009455,
+    "geom:area_square_m":5224590426.845524,
     "geom:bbox":"37.999048,-11.417696,38.887572,-10.683508",
     "geom:latitude":-11.029379,
     "geom:longitude":38.410019,
@@ -54,7 +54,7 @@
     "wof:concordances":{},
     "wof:country":"TZ",
     "wof:created":1474326950,
-    "wof:geomhash":"30d63047f9135c4efd23723431031b84",
+    "wof:geomhash":"fd81b680977cd891c6aeb628870ebd7b",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -64,7 +64,7 @@
         }
     ],
     "wof:id":1108692979,
-    "wof:lastmodified":1627522872,
+    "wof:lastmodified":1695886025,
     "wof:name":"Nanyumbu",
     "wof:parent_id":85679717,
     "wof:placetype":"county",

--- a/data/110/869/298/3/1108692983.geojson
+++ b/data/110/869/298/3/1108692983.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.062263,
-    "geom:area_square_m":756428617.388629,
+    "geom:area_square_m":756428611.346521,
     "geom:bbox":"38.654075,-10.878401,39.103713,-10.623834",
     "geom:latitude":-10.732367,
     "geom:longitude":38.857328,
@@ -54,7 +54,7 @@
     "wof:concordances":{},
     "wof:country":"TZ",
     "wof:created":1474326952,
-    "wof:geomhash":"c0cddf79cabfc729172b76130fb175dd",
+    "wof:geomhash":"633254f6cf40349812ce8745454262c3",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -64,7 +64,7 @@
         }
     ],
     "wof:id":1108692983,
-    "wof:lastmodified":1627522866,
+    "wof:lastmodified":1695886582,
     "wof:name":"Masasi Township Authority",
     "wof:parent_id":85679717,
     "wof:placetype":"county",

--- a/data/110/869/298/5/1108692985.geojson
+++ b/data/110/869/298/5/1108692985.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.522993,
-    "geom:area_square_m":18488523835.237103,
+    "geom:area_square_m":18488523164.396187,
     "geom:bbox":"36.531067,-11.686576,38.112979,-10.104161",
     "geom:latitude":-10.9557,
     "geom:longitude":37.284662,
@@ -123,9 +123,10 @@
     "wof:concordances":{
         "hasc:id":"TZ.RV.TU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TZ",
     "wof:created":1474326953,
-    "wof:geomhash":"6582f66061884d64107bb90fe17abebe",
+    "wof:geomhash":"7efda6ebf6a418b2f37a4ef8b7ba749b",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -135,7 +136,7 @@
         }
     ],
     "wof:id":1108692985,
-    "wof:lastmodified":1636501528,
+    "wof:lastmodified":1695886783,
     "wof:name":"Tunduru",
     "wof:parent_id":85679723,
     "wof:placetype":"county",

--- a/data/110/869/298/7/1108692987.geojson
+++ b/data/110/869/298/7/1108692987.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.159757,
-    "geom:area_square_m":14102901852.971739,
+    "geom:area_square_m":14102903216.945566,
     "geom:bbox":"35.105605,-11.581911,35.945893,-9.248488",
     "geom:latitude":-10.429045,
     "geom:longitude":35.522267,
@@ -86,9 +86,10 @@
         "hasc:id":"TZ.RV.SR",
         "wd:id":"Q1494669"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TZ",
     "wof:created":1474326955,
-    "wof:geomhash":"14c2c8d033e942f510b440da62e5d622",
+    "wof:geomhash":"bb8c1f3e5bb282777631bf4814d9430c",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -98,7 +99,7 @@
         }
     ],
     "wof:id":1108692987,
-    "wof:lastmodified":1690876113,
+    "wof:lastmodified":1695886032,
     "wof:name":"Songea Rural",
     "wof:parent_id":85679723,
     "wof:placetype":"county",

--- a/data/110/869/298/9/1108692989.geojson
+++ b/data/110/869/298/9/1108692989.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.400076,
-    "geom:area_square_m":4859762448.68501,
+    "geom:area_square_m":4859761824.822001,
     "geom:bbox":"34.687239,-11.269538,35.348049,-10.136031",
     "geom:latitude":-10.773726,
     "geom:longitude":34.988772,
@@ -88,9 +88,10 @@
         "hasc:id":"TZ.RV.MB",
         "wd:id":"Q696985"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TZ",
     "wof:created":1474326956,
-    "wof:geomhash":"46281c1ed9dba2a3519ac503ed0b6fad",
+    "wof:geomhash":"5598cda5719f132110e50ada0df40344",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -100,7 +101,7 @@
         }
     ],
     "wof:id":1108692989,
-    "wof:lastmodified":1690876113,
+    "wof:lastmodified":1695886675,
     "wof:name":"Mbinga",
     "wof:parent_id":85679723,
     "wof:placetype":"county",

--- a/data/110/869/299/1/1108692991.geojson
+++ b/data/110/869/299/1/1108692991.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.047783,
-    "geom:area_square_m":580665513.402932,
+    "geom:area_square_m":580665197.671599,
     "geom:bbox":"35.38861,-10.770277,35.776446,-10.504542",
     "geom:latitude":-10.651678,
     "geom:longitude":35.619265,
@@ -85,9 +85,10 @@
         "hasc:id":"TZ.RV.SU",
         "wd:id":"Q2301409"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TZ",
     "wof:created":1474326958,
-    "wof:geomhash":"ad2a5ccb9184194437ccef8bce3febcf",
+    "wof:geomhash":"7af023e4440f4ceb583b2a8588e13348",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -97,7 +98,7 @@
         }
     ],
     "wof:id":1108692991,
-    "wof:lastmodified":1690876116,
+    "wof:lastmodified":1695886033,
     "wof:name":"Songea Urban",
     "wof:parent_id":85679723,
     "wof:placetype":"county",

--- a/data/110/869/299/3/1108692993.geojson
+++ b/data/110/869/299/3/1108692993.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.798411,
-    "geom:area_square_m":21854494820.660259,
+    "geom:area_square_m":21854495043.291996,
     "geom:bbox":"35.645112,-11.762349,37.141159,-9.584492",
     "geom:latitude":-10.636934,
     "geom:longitude":36.317497,
@@ -91,9 +91,10 @@
         "hasc:id":"TZ.RV.NA",
         "wd:id":"Q1964386"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TZ",
     "wof:created":1474326960,
-    "wof:geomhash":"ddb79ca64c5725b7f57996f9882ef525",
+    "wof:geomhash":"2efd1c03fbbeed1053e05238d69aada2",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -103,7 +104,7 @@
         }
     ],
     "wof:id":1108692993,
-    "wof:lastmodified":1690876116,
+    "wof:lastmodified":1695886591,
     "wof:name":"Namtumbo",
     "wof:parent_id":85679723,
     "wof:placetype":"county",

--- a/data/110/869/299/5/1108692995.geojson
+++ b/data/110/869/299/5/1108692995.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.253545,
-    "geom:area_square_m":3074957744.420774,
+    "geom:area_square_m":3074956912.419854,
     "geom:bbox":"34.568596,-11.573244,35.431975,-10.439795",
     "geom:latitude":-11.240662,
     "geom:longitude":35.017557,
@@ -57,7 +57,7 @@
     "wof:concordances":{},
     "wof:country":"TZ",
     "wof:created":1474326962,
-    "wof:geomhash":"a063b1014bb02af49ce4ea2975aaa079",
+    "wof:geomhash":"7f5fd054790dd454fcebe144dc319fcd",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -67,7 +67,7 @@
         }
     ],
     "wof:id":1108692995,
-    "wof:lastmodified":1627522872,
+    "wof:lastmodified":1695886025,
     "wof:name":"Nyasa",
     "wof:parent_id":85679723,
     "wof:placetype":"county",

--- a/data/110/869/299/7/1108692997.geojson
+++ b/data/110/869/299/7/1108692997.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.617099,
-    "geom:area_square_m":7546486662.46686,
+    "geom:area_square_m":7546486884.859016,
     "geom:bbox":"34.683211,-9.040651,35.982014,-8.099443",
     "geom:latitude":-8.510303,
     "geom:longitude":35.271988,
@@ -75,9 +75,10 @@
     "wof:concordances":{
         "hasc:id":"TZ.IG.MU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TZ",
     "wof:created":1474326965,
-    "wof:geomhash":"be0309e92ab2db528f6ea70b84d4fd44",
+    "wof:geomhash":"e62dcf34343d0d86a2be9bc84eb883c4",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -87,7 +88,7 @@
         }
     ],
     "wof:id":1108692997,
-    "wof:lastmodified":1627522870,
+    "wof:lastmodified":1695886590,
     "wof:name":"Mufindi",
     "wof:parent_id":85679711,
     "wof:placetype":"county",

--- a/data/110/869/300/1/1108693001.geojson
+++ b/data/110/869/300/1/1108693001.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.757806,
-    "geom:area_square_m":9283646214.80645,
+    "geom:area_square_m":9283646901.253027,
     "geom:bbox":"35.586781,-8.400831,36.844811,-7.168521",
     "geom:latitude":-7.799307,
     "geom:longitude":36.214102,
@@ -97,9 +97,10 @@
         "hasc:id":"TZ.IG.KI",
         "wd:id":"Q1741422"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TZ",
     "wof:created":1474326967,
-    "wof:geomhash":"b4676440b748ea6dd903fc0b0b41c7dd",
+    "wof:geomhash":"6a51ea3e812a514665c4a0dbc3eb8fd9",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -109,7 +110,7 @@
         }
     ],
     "wof:id":1108693001,
-    "wof:lastmodified":1690876103,
+    "wof:lastmodified":1695886578,
     "wof:name":"Kilolo",
     "wof:parent_id":85679711,
     "wof:placetype":"county",

--- a/data/110/869/300/3/1108693003.geojson
+++ b/data/110/869/300/3/1108693003.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.046999,
-    "geom:area_square_m":574975573.7814,
+    "geom:area_square_m":574975534.222189,
     "geom:bbox":"35.137032,-8.508405,35.408562,-8.216354",
     "geom:latitude":-8.363636,
     "geom:longitude":35.244421,
@@ -54,7 +54,7 @@
     "wof:concordances":{},
     "wof:country":"TZ",
     "wof:created":1474326969,
-    "wof:geomhash":"58409a5e7e80e3cc183b5284c678aa5c",
+    "wof:geomhash":"ee019bfc47264bda63138da776fe142e",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -64,7 +64,7 @@
         }
     ],
     "wof:id":1108693003,
-    "wof:lastmodified":1627522865,
+    "wof:lastmodified":1695886582,
     "wof:name":"Mafinga Township Authority",
     "wof:parent_id":85679711,
     "wof:placetype":"county",

--- a/data/110/869/300/5/1108693005.geojson
+++ b/data/110/869/300/5/1108693005.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.350154,
-    "geom:area_square_m":28794627954.496513,
+    "geom:area_square_m":28794627320.094765,
     "geom:bbox":"32.042197,-8.746744,34.271152,-6.86511",
     "geom:latitude":-7.737444,
     "geom:longitude":33.138083,
@@ -94,9 +94,10 @@
         "hasc:id":"TZ.MB.CH",
         "wd:id":"Q1888356"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TZ",
     "wof:created":1474326970,
-    "wof:geomhash":"fabbe216369a12165067b1d6dc596de7",
+    "wof:geomhash":"9e64231c1ca36fc01f1473d74066d518",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -106,7 +107,7 @@
         }
     ],
     "wof:id":1108693005,
-    "wof:lastmodified":1690876103,
+    "wof:lastmodified":1695886571,
     "wof:name":"Chunya",
     "wof:parent_id":85679641,
     "wof:placetype":"county",

--- a/data/110/869/300/7/1108693007.geojson
+++ b/data/110/869/300/7/1108693007.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.231259,
-    "geom:area_square_m":2824887178.572088,
+    "geom:area_square_m":2824887615.373691,
     "geom:bbox":"33.010067,-9.334219,33.828213,-8.608591",
     "geom:latitude":-8.930361,
     "geom:longitude":33.405047,
@@ -67,9 +67,10 @@
     "wof:concordances":{
         "hasc:id":"TZ.MB.MR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TZ",
     "wof:created":1474326972,
-    "wof:geomhash":"a5a134d2dd28c2a155b72a39a5ac1678",
+    "wof:geomhash":"bed1eca5781b9501e3824a749d73165d",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1108693007,
-    "wof:lastmodified":1627522867,
+    "wof:lastmodified":1695886584,
     "wof:name":"Mbeya Rural",
     "wof:parent_id":85679641,
     "wof:placetype":"county",

--- a/data/110/869/300/9/1108693009.geojson
+++ b/data/110/869/300/9/1108693009.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.17732,
-    "geom:area_square_m":2164195700.8195,
+    "geom:area_square_m":2164195691.545848,
     "geom:bbox":"33.427951,-9.494436,33.984361,-8.978535",
     "geom:latitude":-9.231301,
     "geom:longitude":33.688215,
@@ -88,9 +88,10 @@
         "hasc:id":"TZ.MB.RU",
         "wd:id":"Q7379875"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TZ",
     "wof:created":1474326974,
-    "wof:geomhash":"10c6cfe0b63e765f6841875f8d22c6f8",
+    "wof:geomhash":"15104135d35ddfde698a3f382fd4ab11",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -100,7 +101,7 @@
         }
     ],
     "wof:id":1108693009,
-    "wof:lastmodified":1690876102,
+    "wof:lastmodified":1695886028,
     "wof:name":"Rungwe",
     "wof:parent_id":85679641,
     "wof:placetype":"county",

--- a/data/110/869/301/1/1108693011.geojson
+++ b/data/110/869/301/1/1108693011.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.154792,
-    "geom:area_square_m":1888242907.49324,
+    "geom:area_square_m":1888242558.577523,
     "geom:bbox":"32.873831,-9.623978,33.690104,-9.155336",
     "geom:latitude":-9.416515,
     "geom:longitude":33.342353,
@@ -91,9 +91,10 @@
         "hasc:id":"TZ.MB.IL",
         "wd:id":"Q5997501"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TZ",
     "wof:created":1474326976,
-    "wof:geomhash":"50717bcd840ccd99a162f6be04442abd",
+    "wof:geomhash":"3ce8e0170db62202a2e1955e01a4124e",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -103,7 +104,7 @@
         }
     ],
     "wof:id":1108693011,
-    "wof:lastmodified":1690876104,
+    "wof:lastmodified":1695886574,
     "wof:name":"Ileje",
     "wof:parent_id":85679641,
     "wof:placetype":"county",

--- a/data/110/869/301/3/1108693013.geojson
+++ b/data/110/869/301/3/1108693013.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.317165,
-    "geom:area_square_m":3873984146.065901,
+    "geom:area_square_m":3873983595.657632,
     "geom:bbox":"32.501368,-9.351505,33.266523,-8.592159",
     "geom:latitude":-8.955273,
     "geom:longitude":32.906095,
@@ -97,9 +97,10 @@
         "hasc:id":"TZ.MB.MZ",
         "wd:id":"Q1914938"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TZ",
     "wof:created":1474326977,
-    "wof:geomhash":"16321f96d78b31797dd4e679a6842e9c",
+    "wof:geomhash":"477a19cf2d055e4ef41d7ef7cdc1c4b8",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -109,7 +110,7 @@
         }
     ],
     "wof:id":1108693013,
-    "wof:lastmodified":1690876104,
+    "wof:lastmodified":1695886584,
     "wof:name":"Mbozi",
     "wof:parent_id":85679641,
     "wof:placetype":"county",

--- a/data/110/869/301/5/1108693015.geojson
+++ b/data/110/869/301/5/1108693015.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.185115,
-    "geom:area_square_m":14500795405.46685,
+    "geom:area_square_m":14500795708.169676,
     "geom:bbox":"33.550156,-8.937819,34.968066,-7.618675",
     "geom:latitude":-8.291427,
     "geom:longitude":34.233418,
@@ -85,9 +85,10 @@
         "hasc:id":"TZ.MB.MB",
         "wd:id":"Q6799622"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TZ",
     "wof:created":1474326979,
-    "wof:geomhash":"53995426e494806737a7f46f5eb29616",
+    "wof:geomhash":"6f4298e356fbe0ad3896efb22e00aba1",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -97,7 +98,7 @@
         }
     ],
     "wof:id":1108693015,
-    "wof:lastmodified":1690876105,
+    "wof:lastmodified":1695886582,
     "wof:name":"Mbarali",
     "wof:parent_id":85679641,
     "wof:placetype":"county",

--- a/data/110/869/301/9/1108693019.geojson
+++ b/data/110/869/301/9/1108693019.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.387006,
-    "geom:area_square_m":4728733514.485018,
+    "geom:area_square_m":4728733514.485118,
     "geom:bbox":"32.020008337,-9.337281464,32.912441225,-8.240072512",
     "geom:latitude":-8.822948,
     "geom:longitude":32.423892,
@@ -60,7 +60,7 @@
     "wof:concordances":{},
     "wof:country":"TZ",
     "wof:created":1474326981,
-    "wof:geomhash":"9ee5c1ca3508cc17224497d26dcb2367",
+    "wof:geomhash":"02e078a171bcd173ced3279a1adb9b14",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -70,7 +70,7 @@
         }
     ],
     "wof:id":1108693019,
-    "wof:lastmodified":1566590672,
+    "wof:lastmodified":1695886674,
     "wof:name":"Momba",
     "wof:parent_id":85679641,
     "wof:placetype":"county",

--- a/data/110/869/302/1/1108693021.geojson
+++ b/data/110/869/302/1/1108693021.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.007198,
-    "geom:area_square_m":87834362.871172,
+    "geom:area_square_m":87834507.763144,
     "geom:bbox":"32.728116,-9.370253,32.875817,-9.23669",
     "geom:latitude":-9.298802,
     "geom:longitude":32.799349,
@@ -129,7 +129,7 @@
     "wof:concordances":{},
     "wof:country":"TZ",
     "wof:created":1474326983,
-    "wof:geomhash":"73922d69f2128ab64be76ed5ea36cf7b",
+    "wof:geomhash":"241ac3879a9002057a518189697ddbfd",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -139,7 +139,7 @@
         }
     ],
     "wof:id":1108693021,
-    "wof:lastmodified":1636501528,
+    "wof:lastmodified":1695886783,
     "wof:name":"Tunduma",
     "wof:parent_id":85679641,
     "wof:placetype":"county",

--- a/data/110/869/302/3/1108693023.geojson
+++ b/data/110/869/302/3/1108693023.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.368348,
-    "geom:area_square_m":4541031397.160008,
+    "geom:area_square_m":4541030926.027736,
     "geom:bbox":"33.913544,-4.843372,34.573271,-3.929613",
     "geom:latitude":-4.433693,
     "geom:longitude":34.287132,
@@ -91,9 +91,10 @@
         "hasc:id":"TZ.SD.IR",
         "wd:id":"Q6066646"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TZ",
     "wof:created":1474326984,
-    "wof:geomhash":"48cf1cf7c6551b269ba4c1331c3d7f5d",
+    "wof:geomhash":"b0fc0981265a5ce9d89e43ada150c76c",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -103,7 +104,7 @@
         }
     ],
     "wof:id":1108693023,
-    "wof:lastmodified":1690876112,
+    "wof:lastmodified":1695886574,
     "wof:name":"Iramba",
     "wof:parent_id":85679727,
     "wof:placetype":"county",

--- a/data/110/869/302/5/1108693025.geojson
+++ b/data/110/869/302/5/1108693025.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.195621,
-    "geom:area_square_m":2410691058.563691,
+    "geom:area_square_m":2410690940.899889,
     "geom:bbox":"34.598932,-5.039772,35.340652,-4.405092",
     "geom:latitude":-4.718028,
     "geom:longitude":34.981567,
@@ -121,9 +121,10 @@
     "wof:concordances":{
         "hasc:id":"TZ.SD.SI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TZ",
     "wof:created":1474326986,
-    "wof:geomhash":"494801bcbfa6cf60e207ca108e04c06c",
+    "wof:geomhash":"c5a117c0c1f5972ed6e6bfb7c02c84bf",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -133,7 +134,7 @@
         }
     ],
     "wof:id":1108693025,
-    "wof:lastmodified":1636501528,
+    "wof:lastmodified":1695886783,
     "wof:name":"Singida",
     "wof:parent_id":85679727,
     "wof:placetype":"county",

--- a/data/110/869/302/7/1108693027.geojson
+++ b/data/110/869/302/7/1108693027.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.058742,
-    "geom:area_square_m":723778084.572219,
+    "geom:area_square_m":723778206.339545,
     "geom:bbox":"34.549757,-4.966344,34.885875,-4.661023",
     "geom:latitude":-4.831538,
     "geom:longitude":34.720363,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"TZ.SD.SU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TZ",
     "wof:created":1474326989,
-    "wof:geomhash":"80c69b321e814f1df3e2c9acbf4bcd4b",
+    "wof:geomhash":"d0397b91b17d09557aa6095fbff6fb57",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1108693027,
-    "wof:lastmodified":1627522877,
+    "wof:lastmodified":1695886033,
     "wof:name":"Singida Urban",
     "wof:parent_id":85679727,
     "wof:placetype":"county",

--- a/data/110/869/302/9/1108693029.geojson
+++ b/data/110/869/302/9/1108693029.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.722681,
-    "geom:area_square_m":8900214369.648737,
+    "geom:area_square_m":8900214474.1366,
     "geom:bbox":"33.913473,-5.62859,35.1856,-4.618804",
     "geom:latitude":-5.13145,
     "geom:longitude":34.518281,
@@ -66,7 +66,7 @@
     "wof:concordances":{},
     "wof:country":"TZ",
     "wof:created":1474326990,
-    "wof:geomhash":"50ca1a81528f3bf6844bfbda82f77324",
+    "wof:geomhash":"a72e25329b92480a96414dd7f35dd58f",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -76,7 +76,7 @@
         }
     ],
     "wof:id":1108693029,
-    "wof:lastmodified":1627522859,
+    "wof:lastmodified":1695886572,
     "wof:name":"Ikungi",
     "wof:parent_id":85679727,
     "wof:placetype":"county",

--- a/data/110/869/303/1/1108693031.geojson
+++ b/data/110/869/303/1/1108693031.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.254207,
-    "geom:area_square_m":3134859780.824366,
+    "geom:area_square_m":3134859846.229636,
     "geom:bbox":"34.504447,-4.623432,34.990251,-3.800776",
     "geom:latitude":-4.199944,
     "geom:longitude":34.715559,
@@ -54,7 +54,7 @@
     "wof:concordances":{},
     "wof:country":"TZ",
     "wof:created":1474326992,
-    "wof:geomhash":"a0fdd8b3a53a9bd4f8e0a44a2574549e",
+    "wof:geomhash":"6a7e33166c70139306019991ab27e628",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -64,7 +64,7 @@
         }
     ],
     "wof:id":1108693031,
-    "wof:lastmodified":1627522868,
+    "wof:lastmodified":1695886585,
     "wof:name":"Mkalama",
     "wof:parent_id":85679727,
     "wof:placetype":"county",

--- a/data/110/869/303/3/1108693033.geojson
+++ b/data/110/869/303/3/1108693033.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.640735,
-    "geom:area_square_m":7899521808.571315,
+    "geom:area_square_m":7899522195.740546,
     "geom:bbox":"32.53549,-4.900738,33.419362,-3.8984",
     "geom:latitude":-4.387762,
     "geom:longitude":33.012428,
@@ -139,9 +139,10 @@
         "hasc:id":"TZ.TB.NZ",
         "wd:id":"Q6272309"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TZ",
     "wof:created":1474326994,
-    "wof:geomhash":"daec312b36e95f039ab166bd33100d68",
+    "wof:geomhash":"8143e1e438944fac45dfbb255317069c",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -151,7 +152,7 @@
         }
     ],
     "wof:id":1108693033,
-    "wof:lastmodified":1690876111,
+    "wof:lastmodified":1695886782,
     "wof:name":"Nzega",
     "wof:parent_id":85679661,
     "wof:placetype":"county",

--- a/data/110/869/303/7/1108693037.geojson
+++ b/data/110/869/303/7/1108693037.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.575539,
-    "geom:area_square_m":7096146998.795798,
+    "geom:area_square_m":7096147232.328734,
     "geom:bbox":"33.342567,-4.879929,34.17373,-3.876684",
     "geom:latitude":-4.343733,
     "geom:longitude":33.687961,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"TZ.TB.IG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TZ",
     "wof:created":1474326995,
-    "wof:geomhash":"eef8299a5b6a0566b346a33d7602a914",
+    "wof:geomhash":"9784b9ac79c4d0d05499b52d9a9233cd",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1108693037,
-    "wof:lastmodified":1627522859,
+    "wof:lastmodified":1695886573,
     "wof:name":"Igunga",
     "wof:parent_id":85679661,
     "wof:placetype":"county",

--- a/data/110/869/303/9/1108693039.geojson
+++ b/data/110/869/303/9/1108693039.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.975991,
-    "geom:area_square_m":12020338358.126308,
+    "geom:area_square_m":12020338558.424242,
     "geom:bbox":"32.196729,-5.706855,34.242038,-4.173647",
     "geom:latitude":-5.103366,
     "geom:longitude":33.288096,
@@ -91,9 +91,10 @@
         "hasc:id":"TZ.TB.UY",
         "wd:id":"Q7904403"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TZ",
     "wof:created":1474326997,
-    "wof:geomhash":"c14a91918900464a86f8bc147f01d437",
+    "wof:geomhash":"ab14fba3d3a27518fa549e275f8c67f3",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -103,7 +104,7 @@
         }
     ],
     "wof:id":1108693039,
-    "wof:lastmodified":1690876111,
+    "wof:lastmodified":1695886035,
     "wof:name":"Uyui",
     "wof:parent_id":85679661,
     "wof:placetype":"county",

--- a/data/110/869/304/1/1108693041.geojson
+++ b/data/110/869/304/1/1108693041.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.44181,
-    "geom:area_square_m":5439868260.309776,
+    "geom:area_square_m":5439868737.881553,
     "geom:bbox":"31.845351,-5.776605,32.488376,-4.689983",
     "geom:latitude":-5.275716,
     "geom:longitude":32.134969,
@@ -94,9 +94,10 @@
         "hasc:id":"TZ.TB.UR",
         "wd:id":"Q2500021"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TZ",
     "wof:created":1474326998,
-    "wof:geomhash":"94469711609ec7e68c5870cd59a2f614",
+    "wof:geomhash":"dfef566b098a4c4d4637199182c93f2b",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -106,7 +107,7 @@
         }
     ],
     "wof:id":1108693041,
-    "wof:lastmodified":1690876111,
+    "wof:lastmodified":1695886034,
     "wof:name":"Urambo",
     "wof:parent_id":85679661,
     "wof:placetype":"county",

--- a/data/110/869/304/3/1108693043.geojson
+++ b/data/110/869/304/3/1108693043.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.146623,
-    "geom:area_square_m":26395431943.93465,
+    "geom:area_square_m":26395433152.579876,
     "geom:bbox":"32.027864,-6.976729,34.11004,-5.195317",
     "geom:latitude":-6.039301,
     "geom:longitude":33.095824,
@@ -135,9 +135,10 @@
     "wof:concordances":{
         "hasc:id":"TZ.TB.SI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TZ",
     "wof:created":1474327000,
-    "wof:geomhash":"ec78536e2ff5e20587b3788c3eb7671b",
+    "wof:geomhash":"afa5bb933155ff7821bd808c9a93aff6",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -147,7 +148,7 @@
         }
     ],
     "wof:id":1108693043,
-    "wof:lastmodified":1636501527,
+    "wof:lastmodified":1695886782,
     "wof:name":"Sikonge",
     "wof:parent_id":85679661,
     "wof:placetype":"county",

--- a/data/110/869/304/5/1108693045.geojson
+++ b/data/110/869/304/5/1108693045.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.119118,
-    "geom:area_square_m":1467327749.1487,
+    "geom:area_square_m":1467327533.505791,
     "geom:bbox":"32.632594,-5.212525,32.993943,-4.670307",
     "geom:latitude":-4.992899,
     "geom:longitude":32.795384,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"TZ.TB.TA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TZ",
     "wof:created":1474327001,
-    "wof:geomhash":"8ce225bb0dcb38cac710312451dba689",
+    "wof:geomhash":"d55e887589735d5fc282856f771e55b2",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1108693045,
-    "wof:lastmodified":1627522877,
+    "wof:lastmodified":1695886033,
     "wof:name":"Tabora Urban",
     "wof:parent_id":85679661,
     "wof:placetype":"county",

--- a/data/110/869/304/7/1108693047.geojson
+++ b/data/110/869/304/7/1108693047.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.2505,
-    "geom:area_square_m":15404452598.799282,
+    "geom:area_square_m":15404451767.851332,
     "geom:bbox":"31.038017,-5.837199,32.494629,-4.053106",
     "geom:latitude":-4.95149,
     "geom:longitude":31.735275,
@@ -66,7 +66,7 @@
     "wof:concordances":{},
     "wof:country":"TZ",
     "wof:created":1474327003,
-    "wof:geomhash":"1a87d2e9a38d308d02a929b5c179a3f3",
+    "wof:geomhash":"6bc4ec13c513ea84c229dc301c6ea651",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -76,7 +76,7 @@
         }
     ],
     "wof:id":1108693047,
-    "wof:lastmodified":1627522861,
+    "wof:lastmodified":1695886575,
     "wof:name":"Kaliua",
     "wof:parent_id":85679661,
     "wof:placetype":"county",

--- a/data/110/869/304/9/1108693049.geojson
+++ b/data/110/869/304/9/1108693049.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.457394,
-    "geom:area_square_m":5593251447.441164,
+    "geom:area_square_m":5593251385.449854,
     "geom:bbox":"31.02031,-9.073342,32.142196,-8.003113",
     "geom:latitude":-8.523721,
     "geom:longitude":31.571729,
@@ -69,7 +69,7 @@
     "wof:concordances":{},
     "wof:country":"TZ",
     "wof:created":1474327004,
-    "wof:geomhash":"029f93a03152169acc5f6844defbd15d",
+    "wof:geomhash":"c6bd7531381fa8dd44161b4fb38370a5",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -79,7 +79,7 @@
         }
     ],
     "wof:id":1108693049,
-    "wof:lastmodified":1627522861,
+    "wof:lastmodified":1695886575,
     "wof:name":"Kalambo",
     "wof:parent_id":85679645,
     "wof:placetype":"county",

--- a/data/110/869/305/1/1108693051.geojson
+++ b/data/110/869/305/1/1108693051.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.422659,
-    "geom:area_square_m":5172404465.861801,
+    "geom:area_square_m":5172403648.766559,
     "geom:bbox":"31.375294,-8.762772,32.453776,-7.408074",
     "geom:latitude":-8.227255,
     "geom:longitude":31.943828,
@@ -89,9 +89,10 @@
         "hasc:id":"TZ.RU.SR",
         "wd:id":"Q3710540"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TZ",
     "wof:created":1474327006,
-    "wof:geomhash":"85dfa91a6d48415d5905c5c4ef11f339",
+    "wof:geomhash":"c7fe644495d78f6001a6f38ce76bc19c",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -101,7 +102,7 @@
         }
     ],
     "wof:id":1108693051,
-    "wof:lastmodified":1690876112,
+    "wof:lastmodified":1695886033,
     "wof:name":"Sumbawanga Rural",
     "wof:parent_id":85679645,
     "wof:placetype":"county",

--- a/data/110/869/305/5/1108693055.geojson
+++ b/data/110/869/305/5/1108693055.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.804941,
-    "geom:area_square_m":9866756141.620731,
+    "geom:area_square_m":9866756565.383221,
     "geom:bbox":"30.49938,-8.288596,31.522572,-6.884823",
     "geom:latitude":-7.552078,
     "geom:longitude":31.005097,
@@ -91,9 +91,10 @@
         "hasc:id":"TZ.RU.NK",
         "wd:id":"Q3711254"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TZ",
     "wof:created":1474327007,
-    "wof:geomhash":"cb4c4c1c66b97d5fe98e2ac767705587",
+    "wof:geomhash":"0b88afa310842f7da7a122bf29b25964",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -103,7 +104,7 @@
         }
     ],
     "wof:id":1108693055,
-    "wof:lastmodified":1690876112,
+    "wof:lastmodified":1695886026,
     "wof:name":"Nkasi",
     "wof:parent_id":85679645,
     "wof:placetype":"county",

--- a/data/110/869/305/7/1108693057.geojson
+++ b/data/110/869/305/7/1108693057.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.112675,
-    "geom:area_square_m":1379746308.026222,
+    "geom:area_square_m":1379746394.400199,
     "geom:bbox":"31.404141,-8.185812,31.853022,-7.765109",
     "geom:latitude":-7.981096,
     "geom:longitude":31.615159,
@@ -91,9 +91,10 @@
         "hasc:id":"TZ.RU.SU",
         "wd:id":"Q3710549"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TZ",
     "wof:created":1474327009,
-    "wof:geomhash":"421a4dbf0dabedbc0b163e5adb785dd5",
+    "wof:geomhash":"bb6925fc5497c29856473d9935c155e6",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -103,7 +104,7 @@
         }
     ],
     "wof:id":1108693057,
-    "wof:lastmodified":1690876111,
+    "wof:lastmodified":1695886033,
     "wof:name":"Sumbawanga Urban",
     "wof:parent_id":85679645,
     "wof:placetype":"county",

--- a/data/110/869/305/9/1108693059.geojson
+++ b/data/110/869/305/9/1108693059.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.091978,
-    "geom:area_square_m":13466689389.926495,
+    "geom:area_square_m":13466690072.849651,
     "geom:bbox":"30.386547,-4.994568,31.492551,-3.373294",
     "geom:latitude":-4.154573,
     "geom:longitude":30.979339,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"TZ.KM.KI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TZ",
     "wof:created":1474327010,
-    "wof:geomhash":"baafa4e5341712784f6f24dfd4087b77",
+    "wof:geomhash":"3716a6e20ae4d744d4c71b9a6ba99db1",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1108693059,
-    "wof:lastmodified":1627522862,
+    "wof:lastmodified":1695886577,
     "wof:name":"Kibondo",
     "wof:parent_id":85679669,
     "wof:placetype":"county",

--- a/data/110/869/306/1/1108693061.geojson
+++ b/data/110/869/306/1/1108693061.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.586315,
-    "geom:area_square_m":7227390322.021139,
+    "geom:area_square_m":7227390261.6056,
     "geom:bbox":"29.892555,-5.094738,30.927918,-3.773478",
     "geom:latitude":-4.504974,
     "geom:longitude":30.423426,
@@ -120,9 +120,10 @@
     "wof:concordances":{
         "hasc:id":"TZ.KM.KA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TZ",
     "wof:created":1474327012,
-    "wof:geomhash":"95da1be1efaf8aaf0ae83182502513ed",
+    "wof:geomhash":"86e4289552096e61afe82ec2f1d9f13e",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -132,7 +133,7 @@
         }
     ],
     "wof:id":1108693061,
-    "wof:lastmodified":1636501525,
+    "wof:lastmodified":1695886781,
     "wof:name":"Kasulu",
     "wof:parent_id":85679669,
     "wof:placetype":"county",

--- a/data/110/869/306/3/1108693063.geojson
+++ b/data/110/869/306/3/1108693063.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.007556,
-    "geom:area_square_m":93090492.573109,
+    "geom:area_square_m":93090513.770453,
     "geom:bbox":"29.589529,-4.969158,29.731043,-4.819283",
     "geom:latitude":-4.891769,
     "geom:longitude":29.66589,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"TZ.KM.KU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TZ",
     "wof:created":1474327015,
-    "wof:geomhash":"f82bab42bd73ca371e0d4908d19652e8",
+    "wof:geomhash":"548943e45ac94f09a40ea0b641398fa0",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1108693063,
-    "wof:lastmodified":1627522863,
+    "wof:lastmodified":1695886579,
     "wof:name":"Kigoma Municipal-Ujiji",
     "wof:parent_id":85679669,
     "wof:placetype":"county",

--- a/data/110/869/306/5/1108693065.geojson
+++ b/data/110/869/306/5/1108693065.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.820567,
-    "geom:area_square_m":10098971477.605728,
+    "geom:area_square_m":10098972137.750616,
     "geom:bbox":"29.699355,-6.570679,31.260787,-4.836705",
     "geom:latitude":-5.522026,
     "geom:longitude":30.24875,
@@ -123,7 +123,7 @@
     "wof:concordances":{},
     "wof:country":"TZ",
     "wof:created":1474327016,
-    "wof:geomhash":"104ae8c661a2bc326069d649f3eec1ad",
+    "wof:geomhash":"1e775e093f8c62e5cf35567cea84365f",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -133,7 +133,7 @@
         }
     ],
     "wof:id":1108693065,
-    "wof:lastmodified":1636501526,
+    "wof:lastmodified":1695886782,
     "wof:name":"Uvinza",
     "wof:parent_id":85679669,
     "wof:placetype":"county",

--- a/data/110/869/306/7/1108693067.geojson
+++ b/data/110/869/306/7/1108693067.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.122738,
-    "geom:area_square_m":1513077989.044336,
+    "geom:area_square_m":1513078050.783616,
     "geom:bbox":"29.7568,-4.839733,30.215945,-4.114805",
     "geom:latitude":-4.459398,
     "geom:longitude":29.953345,
@@ -60,7 +60,7 @@
     "wof:concordances":{},
     "wof:country":"TZ",
     "wof:created":1474327018,
-    "wof:geomhash":"22467f6dd5e0de17d5155c89efe6cc13",
+    "wof:geomhash":"d400085ec78440ba31451868bcd133e8",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -70,7 +70,7 @@
         }
     ],
     "wof:id":1108693067,
-    "wof:lastmodified":1627522857,
+    "wof:lastmodified":1695886569,
     "wof:name":"Buhigwe",
     "wof:parent_id":85679669,
     "wof:placetype":"county",

--- a/data/110/869/306/9/1108693069.geojson
+++ b/data/110/869/306/9/1108693069.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.17972,
-    "geom:area_square_m":2218722712.711555,
+    "geom:area_square_m":2218722221.871448,
     "geom:bbox":"30.501897,-3.592032,31.19646,-2.827975",
     "geom:latitude":-3.233518,
     "geom:longitude":30.899886,
@@ -106,7 +106,7 @@
     "wof:concordances":{},
     "wof:country":"TZ",
     "wof:created":1474327020,
-    "wof:geomhash":"f17525f122d3f0f104fa56c0c1b3d02c",
+    "wof:geomhash":"45216d7644721b5e94e1052a09a63b18",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -116,7 +116,7 @@
         }
     ],
     "wof:id":1108693069,
-    "wof:lastmodified":1636501525,
+    "wof:lastmodified":1695886781,
     "wof:name":"Kakonko",
     "wof:parent_id":85679669,
     "wof:placetype":"county",

--- a/data/110/869/307/3/1108693073.geojson
+++ b/data/110/869/307/3/1108693073.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.074309,
-    "geom:area_square_m":915902234.085545,
+    "geom:area_square_m":915902179.742071,
     "geom:bbox":"29.920064,-4.760633,30.259199,-4.404033",
     "geom:latitude":-4.587009,
     "geom:longitude":30.094404,
@@ -54,7 +54,7 @@
     "wof:concordances":{},
     "wof:country":"TZ",
     "wof:created":1474327021,
-    "wof:geomhash":"b78b5b221ccc35b785541400e15da9d8",
+    "wof:geomhash":"0201c4d4b8822c9da1e76eda36de3a18",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -64,7 +64,7 @@
         }
     ],
     "wof:id":1108693073,
-    "wof:lastmodified":1627522862,
+    "wof:lastmodified":1695886577,
     "wof:name":"Kasulu Township Authority",
     "wof:parent_id":85679669,
     "wof:placetype":"county",

--- a/data/110/869/307/5/1108693075.geojson
+++ b/data/110/869/307/5/1108693075.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.045151,
-    "geom:area_square_m":557178372.508597,
+    "geom:area_square_m":557178456.731208,
     "geom:bbox":"33.311663,-3.758406,33.586376,-3.490014",
     "geom:latitude":-3.62573,
     "geom:longitude":33.4453,
@@ -85,9 +85,10 @@
         "hasc:id":"TZ.SY.SU",
         "wd:id":"Q7497842"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TZ",
     "wof:created":1474327023,
-    "wof:geomhash":"229b46d53aacc6f938ed63cce5ba1dc1",
+    "wof:geomhash":"466d28094917822fdcdb64681a4bf626",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -97,7 +98,7 @@
         }
     ],
     "wof:id":1108693075,
-    "wof:lastmodified":1690876102,
+    "wof:lastmodified":1695886031,
     "wof:name":"Shinyanga Urban",
     "wof:parent_id":85679657,
     "wof:placetype":"county",

--- a/data/110/869/307/7/1108693077.geojson
+++ b/data/110/869/307/7/1108693077.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.340467,
-    "geom:area_square_m":4201198218.363069,
+    "geom:area_square_m":4201198043.802547,
     "geom:bbox":"33.152624,-4.077654,34.233575,-3.283046",
     "geom:latitude":-3.689174,
     "geom:longitude":33.758639,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"TZ.SY.KI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TZ",
     "wof:created":1474327024,
-    "wof:geomhash":"8fec583f59b2a9f6eb18a9aaac6657b5",
+    "wof:geomhash":"cc1268ea95131ace7546f3741b83745e",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1108693077,
-    "wof:lastmodified":1627522864,
+    "wof:lastmodified":1695886580,
     "wof:name":"Kishapu",
     "wof:parent_id":85679657,
     "wof:placetype":"county",

--- a/data/110/869/307/9/1108693079.geojson
+++ b/data/110/869/307/9/1108693079.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.290486,
-    "geom:area_square_m":3584701999.593688,
+    "geom:area_square_m":3584701645.426457,
     "geom:bbox":"32.681933,-3.966058,33.532248,-3.229841",
     "geom:latitude":-3.628861,
     "geom:longitude":33.09652,
@@ -67,9 +67,10 @@
     "wof:concordances":{
         "hasc:id":"TZ.SY.SR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TZ",
     "wof:created":1474327026,
-    "wof:geomhash":"3cc570fe023dadf358f37b0f62a3be8e",
+    "wof:geomhash":"5dd721bfebfde23282e59800787a90dc",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1108693079,
-    "wof:lastmodified":1627522876,
+    "wof:lastmodified":1695886032,
     "wof:name":"Shinyanga Rural",
     "wof:parent_id":85679657,
     "wof:placetype":"county",

--- a/data/110/869/308/1/1108693081.geojson
+++ b/data/110/869/308/1/1108693081.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.549968,
-    "geom:area_square_m":6785056394.359704,
+    "geom:area_square_m":6785056935.055246,
     "geom:bbox":"31.682261,-4.3243,33.000673,-3.195402",
     "geom:latitude":-3.84768,
     "geom:longitude":32.368702,
@@ -111,9 +111,10 @@
     "wof:concordances":{
         "hasc:id":"TZ.SY.KA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TZ",
     "wof:created":1474327028,
-    "wof:geomhash":"ab65429305494d11a768cb4d9790b714",
+    "wof:geomhash":"cf23b2be120da7bfb7dd1da9c40f47f9",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -123,7 +124,7 @@
         }
     ],
     "wof:id":1108693081,
-    "wof:lastmodified":1636501525,
+    "wof:lastmodified":1695886781,
     "wof:name":"Kahama",
     "wof:parent_id":85679657,
     "wof:placetype":"county",

--- a/data/110/869/308/3/1108693083.geojson
+++ b/data/110/869/308/3/1108693083.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.110991,
-    "geom:area_square_m":1369336193.064202,
+    "geom:area_square_m":1369336272.634303,
     "geom:bbox":"32.366377,-4.050004,32.852319,-3.626967",
     "geom:latitude":-3.843614,
     "geom:longitude":32.597266,
@@ -54,7 +54,7 @@
     "wof:concordances":{},
     "wof:country":"TZ",
     "wof:created":1474327029,
-    "wof:geomhash":"eb31c6723dc44866aac188b97b6ffed7",
+    "wof:geomhash":"65774d13c2649c00aa34335b76f93a80",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -64,7 +64,7 @@
         }
     ],
     "wof:id":1108693083,
-    "wof:lastmodified":1627522861,
+    "wof:lastmodified":1695886575,
     "wof:name":"Kahama Township Authority",
     "wof:parent_id":85679657,
     "wof:placetype":"county",

--- a/data/110/869/308/5/1108693085.geojson
+++ b/data/110/869/308/5/1108693085.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.417263,
-    "geom:area_square_m":5157072561.538357,
+    "geom:area_square_m":5157072867.873479,
     "geom:bbox":"30.775275,-2.258119,31.392171,-1.184626",
     "geom:latitude":-1.74938,
     "geom:longitude":31.091138,
@@ -91,9 +91,10 @@
         "hasc:id":"TZ.KG.KA",
         "wd:id":"Q3711033"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TZ",
     "wof:created":1474327031,
-    "wof:geomhash":"2a78559b22d8c6b386d1cd1681fe3e00",
+    "wof:geomhash":"079602f541a899bf7b9e565b9d89c6bd",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -103,7 +104,7 @@
         }
     ],
     "wof:id":1108693085,
-    "wof:lastmodified":1690876104,
+    "wof:lastmodified":1695886575,
     "wof:name":"Karagwe",
     "wof:parent_id":85679665,
     "wof:placetype":"county",

--- a/data/110/869/308/7/1108693087.geojson
+++ b/data/110/869/308/7/1108693087.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.131478,
-    "geom:area_square_m":1625238127.269361,
+    "geom:area_square_m":1625238110.948837,
     "geom:bbox":"31.328931,-1.702374,31.880005,-1.003834",
     "geom:latitude":-1.431517,
     "geom:longitude":31.586198,
@@ -67,9 +67,10 @@
     "wof:concordances":{
         "hasc:id":"TZ.KG.BR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TZ",
     "wof:created":1474327032,
-    "wof:geomhash":"fc73a7aa492a89693257dd321e680f4c",
+    "wof:geomhash":"305e658b69c394c8c791632444a8ece1",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1108693087,
-    "wof:lastmodified":1627522857,
+    "wof:lastmodified":1695886570,
     "wof:name":"Bukoba Rural",
     "wof:parent_id":85679665,
     "wof:placetype":"county",

--- a/data/110/869/309/1/1108693091.geojson
+++ b/data/110/869/309/1/1108693091.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.284703,
-    "geom:area_square_m":3518429897.86828,
+    "geom:area_square_m":3518430057.709846,
     "geom:bbox":"31.187627,-2.406752,32.617735,-1.439268",
     "geom:latitude":-1.911797,
     "geom:longitude":31.512029,
@@ -100,9 +100,10 @@
         "hasc:id":"TZ.KG.MU",
         "wd:id":"Q6933906"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TZ",
     "wof:created":1474327034,
-    "wof:geomhash":"3d54d241a49a2c41853d2047ea15cf9b",
+    "wof:geomhash":"0894ab70df92d81f61cb5ad5afc6ae37",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -112,7 +113,7 @@
         }
     ],
     "wof:id":1108693091,
-    "wof:lastmodified":1690876103,
+    "wof:lastmodified":1695886592,
     "wof:name":"Muleba",
     "wof:parent_id":85679665,
     "wof:placetype":"county",

--- a/data/110/869/309/3/1108693093.geojson
+++ b/data/110/869/309/3/1108693093.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.607038,
-    "geom:area_square_m":7497460388.751276,
+    "geom:area_square_m":7497460925.58737,
     "geom:bbox":"30.799242,-3.360234,31.721419,-2.184119",
     "geom:latitude":-2.739453,
     "geom:longitude":31.256843,
@@ -127,9 +127,10 @@
         "hasc:id":"TZ.KG.BI",
         "wd:id":"Q6273464"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TZ",
     "wof:created":1474327036,
-    "wof:geomhash":"cbe64d8690291ecc9a5aa3b143cfbf73",
+    "wof:geomhash":"99b87809adde4b9c02662ffbe25a11ae",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -139,7 +140,7 @@
         }
     ],
     "wof:id":1108693093,
-    "wof:lastmodified":1690876104,
+    "wof:lastmodified":1695886780,
     "wof:name":"Biharamulo",
     "wof:parent_id":85679665,
     "wof:placetype":"county",

--- a/data/110/869/309/5/1108693095.geojson
+++ b/data/110/869/309/5/1108693095.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.268785,
-    "geom:area_square_m":3320033291.896575,
+    "geom:area_square_m":3320033089.922594,
     "geom:bbox":"30.410674,-2.99735,31.065507,-2.254746",
     "geom:latitude":-2.64172,
     "geom:longitude":30.71095,
@@ -129,9 +129,10 @@
     "wof:concordances":{
         "hasc:id":"TZ.KG.NG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TZ",
     "wof:created":1474327037,
-    "wof:geomhash":"bc3adee032e74dc70f6def42c7340443",
+    "wof:geomhash":"6ca854ef78b30d709f7582acaa9c8f90",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -141,7 +142,7 @@
         }
     ],
     "wof:id":1108693095,
-    "wof:lastmodified":1636501525,
+    "wof:lastmodified":1695886781,
     "wof:name":"Ngara",
     "wof:parent_id":85679665,
     "wof:placetype":"county",

--- a/data/110/869/309/7/1108693097.geojson
+++ b/data/110/869/309/7/1108693097.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.006764,
-    "geom:area_square_m":83619863.294731,
+    "geom:area_square_m":83619895.716616,
     "geom:bbox":"31.765299,-1.385464,31.868398,-1.257535",
     "geom:latitude":-1.317135,
     "geom:longitude":31.804956,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"TZ.KG.BU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TZ",
     "wof:created":1474327039,
-    "wof:geomhash":"769824556d118a83ea8eaac7822d703c",
+    "wof:geomhash":"e2b1d37b82cb35c71c2024ac82a68a40",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1108693097,
-    "wof:lastmodified":1627522857,
+    "wof:lastmodified":1695886570,
     "wof:name":"Bukoba Urban",
     "wof:parent_id":85679665,
     "wof:placetype":"county",

--- a/data/110/869/309/9/1108693099.geojson
+++ b/data/110/869/309/9/1108693099.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.22954,
-    "geom:area_square_m":2837735059.642149,
+    "geom:area_square_m":2837733783.460682,
     "geom:bbox":"30.798149,-1.413813,31.81188,-0.995037",
     "geom:latitude":-1.142268,
     "geom:longitude":31.40938,
@@ -54,7 +54,7 @@
     "wof:concordances":{},
     "wof:country":"TZ",
     "wof:created":1474327040,
-    "wof:geomhash":"91385277e41b85729562057678103401",
+    "wof:geomhash":"a498e73785edad6d09f45206a120a408",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -64,7 +64,7 @@
         }
     ],
     "wof:id":1108693099,
-    "wof:lastmodified":1627522867,
+    "wof:lastmodified":1695886585,
     "wof:name":"Missenyi",
     "wof:parent_id":85679665,
     "wof:placetype":"county",

--- a/data/110/869/310/1/1108693101.geojson
+++ b/data/110/869/310/1/1108693101.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.203653,
-    "geom:area_square_m":2517592776.525023,
+    "geom:area_square_m":2517593775.825531,
     "geom:bbox":"30.49806,-1.615052,31.061567,-0.983143",
     "geom:latitude":-1.261062,
     "geom:longitude":30.788344,
@@ -54,7 +54,7 @@
     "wof:concordances":{},
     "wof:country":"TZ",
     "wof:created":1474327042,
-    "wof:geomhash":"96302a864f415bc2b8a860ea87f23f59",
+    "wof:geomhash":"ed4f216a5a414c118c0d593c4ce54913",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -64,7 +64,7 @@
         }
     ],
     "wof:id":1108693101,
-    "wof:lastmodified":1627522865,
+    "wof:lastmodified":1695886582,
     "wof:name":"Kyerwa",
     "wof:parent_id":85679665,
     "wof:placetype":"county",

--- a/data/110/869/310/3/1108693103.geojson
+++ b/data/110/869/310/3/1108693103.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.051058,
-    "geom:area_square_m":630963046.354025,
+    "geom:area_square_m":630963059.989659,
     "geom:bbox":"32.776045,-2.175638,33.430959,-1.667174",
     "geom:latitude":-1.99813,
     "geom:longitude":33.014368,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"TZ.MZ.UK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TZ",
     "wof:created":1474327043,
-    "wof:geomhash":"42aefd0787a2a5bc364baa8c645af1d1",
+    "wof:geomhash":"1e1257aca8849f0e23ae8dc29b68af97",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1108693103,
-    "wof:lastmodified":1642551718,
+    "wof:lastmodified":1695886499,
     "wof:name":"Ukerewe",
     "wof:parent_id":85679655,
     "wof:placetype":"county",

--- a/data/110/869/310/5/1108693105.geojson
+++ b/data/110/869/310/5/1108693105.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.12339,
-    "geom:area_square_m":1524151601.024027,
+    "geom:area_square_m":1524151400.292624,
     "geom:bbox":"33.011484,-2.836402,33.789809,-2.380738",
     "geom:latitude":-2.613088,
     "geom:longitude":33.401455,
@@ -91,9 +91,10 @@
         "hasc:id":"TZ.MZ.MA",
         "wd:id":"Q1888265"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TZ",
     "wof:created":1474327045,
-    "wof:geomhash":"b64964263847a5e60be9c0a44a7572ca",
+    "wof:geomhash":"666f0cdf204b6649e2a69b79ce65a33e",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -103,7 +104,7 @@
         }
     ],
     "wof:id":1108693105,
-    "wof:lastmodified":1690876119,
+    "wof:lastmodified":1695886582,
     "wof:name":"Magu",
     "wof:parent_id":85679655,
     "wof:placetype":"county",

--- a/data/110/869/310/9/1108693109.geojson
+++ b/data/110/869/310/9/1108693109.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.01486,
-    "geom:area_square_m":183553355.847747,
+    "geom:area_square_m":183553251.245772,
     "geom:bbox":"32.860094,-2.652789,33.027543,-2.498352",
     "geom:latitude":-2.587659,
     "geom:longitude":32.94324,
@@ -88,9 +88,10 @@
         "hasc:id":"TZ.MZ.NY",
         "wd:id":"Q7070845"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TZ",
     "wof:created":1474327047,
-    "wof:geomhash":"477d899635e4785371131d1e46d09023",
+    "wof:geomhash":"2ab9a8e20983ce198958491d2b76bef4",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -100,7 +101,7 @@
         }
     ],
     "wof:id":1108693109,
-    "wof:lastmodified":1690876119,
+    "wof:lastmodified":1695886027,
     "wof:name":"Nyamagana",
     "wof:parent_id":85679655,
     "wof:placetype":"county",

--- a/data/110/869/311/1/1108693111.geojson
+++ b/data/110/869/311/1/1108693111.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.264751,
-    "geom:area_square_m":3269026765.358308,
+    "geom:area_square_m":3269027086.156143,
     "geom:bbox":"32.915981,-3.43541,33.617843,-2.640178",
     "geom:latitude":-3.053201,
     "geom:longitude":33.289248,
@@ -88,9 +88,10 @@
         "hasc:id":"TZ.MZ.KW",
         "wd:id":"Q6450445"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TZ",
     "wof:created":1474327048,
-    "wof:geomhash":"1b8117f2b04b2125bf8272d2a18b6469",
+    "wof:geomhash":"233456921edddddbcdf7782a5d724c09",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -100,7 +101,7 @@
         }
     ],
     "wof:id":1108693111,
-    "wof:lastmodified":1690876116,
+    "wof:lastmodified":1695886580,
     "wof:name":"Kwimba",
     "wof:parent_id":85679655,
     "wof:placetype":"county",

--- a/data/110/869/311/3/1108693113.geojson
+++ b/data/110/869/311/3/1108693113.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.25641,
-    "geom:area_square_m":3167284200.48272,
+    "geom:area_square_m":3167283971.609046,
     "geom:bbox":"31.93281,-3.009382,32.876348,-2.15392",
     "geom:latitude":-2.597105,
     "geom:longitude":32.517473,
@@ -97,9 +97,10 @@
         "hasc:id":"TZ.MZ.SE",
         "wd:id":"Q1888290"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TZ",
     "wof:created":1474327050,
-    "wof:geomhash":"864c863fe3da3085926b25f90d789304",
+    "wof:geomhash":"e7b2cb17282bbc6fb07f5336a3aab02b",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -109,7 +110,7 @@
         }
     ],
     "wof:id":1108693113,
-    "wof:lastmodified":1690876117,
+    "wof:lastmodified":1695886029,
     "wof:name":"Sengerema",
     "wof:parent_id":85679655,
     "wof:placetype":"county",

--- a/data/110/869/311/5/1108693115.geojson
+++ b/data/110/869/311/5/1108693115.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.209819,
-    "geom:area_square_m":2591034090.594485,
+    "geom:area_square_m":2591033617.637788,
     "geom:bbox":"32.765055,-3.303458,33.292536,-2.604267",
     "geom:latitude":-2.936741,
     "geom:longitude":33.011311,
@@ -82,9 +82,10 @@
         "hasc:id":"TZ.MZ.MI",
         "wd:id":"Q16999839"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TZ",
     "wof:created":1474327053,
-    "wof:geomhash":"4ffd397ea4a214be7bc34a2c4d3c55f9",
+    "wof:geomhash":"ea9240ad3724bae47a6784c3c0b83849",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -94,7 +95,7 @@
         }
     ],
     "wof:id":1108693115,
-    "wof:lastmodified":1690876118,
+    "wof:lastmodified":1695886586,
     "wof:name":"Misungwi",
     "wof:parent_id":85679655,
     "wof:placetype":"county",

--- a/data/110/869/311/7/1108693117.geojson
+++ b/data/110/869/311/7/1108693117.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.005269,
-    "geom:area_square_m":65131227.836722,
+    "geom:area_square_m":65131189.960528,
     "geom:bbox":"33.738166,-1.56925,33.854439,-1.473466",
     "geom:latitude":-1.522557,
     "geom:longitude":33.795871,
@@ -89,9 +89,10 @@
         "hasc:id":"TZ.MA.MU",
         "wd:id":"Q6943048"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TZ",
     "wof:created":1474327059,
-    "wof:geomhash":"a408bc60d0d2951987fda56cc37b6d45",
+    "wof:geomhash":"27bd38703d35321b65bb834ce13a11af",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -101,7 +102,7 @@
         }
     ],
     "wof:id":1108693117,
-    "wof:lastmodified":1690876116,
+    "wof:lastmodified":1695886025,
     "wof:name":"Musoma Municipal",
     "wof:parent_id":85679743,
     "wof:placetype":"county",

--- a/data/110/869/311/9/1108693119.geojson
+++ b/data/110/869/311/9/1108693119.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.162674,
-    "geom:area_square_m":2010971554.475199,
+    "geom:area_square_m":2010971431.237931,
     "geom:bbox":"33.762381,-1.570791,34.376663,-1.026221",
     "geom:latitude":-1.305915,
     "geom:longitude":34.074188,
@@ -54,7 +54,7 @@
     "wof:concordances":{},
     "wof:country":"TZ",
     "wof:created":1474327060,
-    "wof:geomhash":"d9131e04397a1ca2fd3f474a9cd109f6",
+    "wof:geomhash":"4528e118f409516a347fc4830d277b8a",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -64,7 +64,7 @@
         }
     ],
     "wof:id":1108693119,
-    "wof:lastmodified":1627522873,
+    "wof:lastmodified":1695886028,
     "wof:name":"Rorya",
     "wof:parent_id":85679743,
     "wof:placetype":"county",

--- a/data/110/869/312/1/1108693121.geojson
+++ b/data/110/869/312/1/1108693121.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.176195,
-    "geom:area_square_m":2177736414.881642,
+    "geom:area_square_m":2177736414.881529,
     "geom:bbox":"33.614404678,-1.952215177,34.306580595,-1.387569999",
     "geom:latitude":-1.683107,
     "geom:longitude":33.970723,
@@ -67,7 +67,7 @@
     "wof:concordances":{},
     "wof:country":"TZ",
     "wof:created":1474327062,
-    "wof:geomhash":"c127f111839adc8799ce14ce61644d03",
+    "wof:geomhash":"5607feab7ef0e637176cf0033c1cb923",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -77,7 +77,7 @@
         }
     ],
     "wof:id":1108693121,
-    "wof:lastmodified":1566590687,
+    "wof:lastmodified":1695886675,
     "wof:name":"Butiama",
     "wof:parent_id":85679743,
     "wof:placetype":"county",

--- a/data/110/869/312/3/1108693123.geojson
+++ b/data/110/869/312/3/1108693123.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.45357,
-    "geom:area_square_m":5594098949.143037,
+    "geom:area_square_m":5594099472.393435,
     "geom:bbox":"35.194567,-4.493571,36.305556,-3.554072",
     "geom:latitude":-4.100097,
     "geom:longitude":35.858246,
@@ -103,9 +103,10 @@
         "hasc:id":"TZ.MY.BA",
         "wd:id":"Q15195819"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TZ",
     "wof:created":1474327063,
-    "wof:geomhash":"9425d03c3ecdd38da69a1157db70222a",
+    "wof:geomhash":"3516217eca218bfed329ceaf412c72e1",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -115,7 +116,7 @@
         }
     ],
     "wof:id":1108693123,
-    "wof:lastmodified":1690876110,
+    "wof:lastmodified":1695886782,
     "wof:name":"Babati",
     "wof:parent_id":85679733,
     "wof:placetype":"county",

--- a/data/110/869/312/7/1108693127.geojson
+++ b/data/110/869/312/7/1108693127.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.309399,
-    "geom:area_square_m":3816664507.02866,
+    "geom:area_square_m":3816664390.939407,
     "geom:bbox":"34.891196,-4.265694,35.698262,-3.614793",
     "geom:latitude":-3.953212,
     "geom:longitude":35.294652,
@@ -148,9 +148,10 @@
         "hasc:id":"TZ.MY.MB",
         "wd:id":"Q1009154"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TZ",
     "wof:created":1474327066,
-    "wof:geomhash":"1bcc6ab0e1f210a5122a357be0f7efd4",
+    "wof:geomhash":"539b7d76fb142b8daa3d875a69a6dbdf",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -160,7 +161,7 @@
         }
     ],
     "wof:id":1108693127,
-    "wof:lastmodified":1690876109,
+    "wof:lastmodified":1695886783,
     "wof:name":"Mbulu",
     "wof:parent_id":85679733,
     "wof:placetype":"county",

--- a/data/110/869/312/9/1108693129.geojson
+++ b/data/110/869/312/9/1108693129.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.071181,
-    "geom:area_square_m":13190027674.898373,
+    "geom:area_square_m":13190027740.44128,
     "geom:bbox":"36.246409,-5.951309,37.386665,-4.436777",
     "geom:latitude":-5.226486,
     "geom:longitude":36.761577,
@@ -97,9 +97,10 @@
         "hasc:id":"TZ.MY.KI",
         "wd:id":"Q2220741"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TZ",
     "wof:created":1474327068,
-    "wof:geomhash":"5a1a6715ab92669925b6de535ce0d667",
+    "wof:geomhash":"aa387894b269132e041d8f54f1f439b5",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -109,7 +110,7 @@
         }
     ],
     "wof:id":1108693129,
-    "wof:lastmodified":1690876109,
+    "wof:lastmodified":1695886580,
     "wof:name":"Kiteto",
     "wof:parent_id":85679733,
     "wof:placetype":"county",

--- a/data/110/869/313/1/1108693131.geojson
+++ b/data/110/869/313/1/1108693131.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.038365,
-    "geom:area_square_m":473112069.397362,
+    "geom:area_square_m":473112031.832755,
     "geom:bbox":"35.60739,-4.355082,35.846312,-4.071951",
     "geom:latitude":-4.199871,
     "geom:longitude":35.744678,
@@ -54,7 +54,7 @@
     "wof:concordances":{},
     "wof:country":"TZ",
     "wof:created":1474327070,
-    "wof:geomhash":"4905363fe6a91f7cd33f3abfc7453580",
+    "wof:geomhash":"eab70dd2c87edd29c14e17c2ae6e7458",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -64,7 +64,7 @@
         }
     ],
     "wof:id":1108693131,
-    "wof:lastmodified":1627522857,
+    "wof:lastmodified":1695886570,
     "wof:name":"Babati Urban",
     "wof:parent_id":85679733,
     "wof:placetype":"county",

--- a/data/110/869/313/3/1108693133.geojson
+++ b/data/110/869/313/3/1108693133.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.291175,
-    "geom:area_square_m":3550895531.975828,
+    "geom:area_square_m":3550895646.147794,
     "geom:bbox":"34.391222,-9.763936,35.306744,-9.171282",
     "geom:latitude":-9.515381,
     "geom:longitude":34.886493,
@@ -54,7 +54,7 @@
     "wof:concordances":{},
     "wof:country":"TZ",
     "wof:created":1474327071,
-    "wof:geomhash":"6d91a88e35a38d5c41c897d2c0bdc35e",
+    "wof:geomhash":"2317c5e91446cba0be307c6d4c07aab6",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -64,7 +64,7 @@
         }
     ],
     "wof:id":1108693133,
-    "wof:lastmodified":1627522872,
+    "wof:lastmodified":1695886027,
     "wof:name":"Njombe Urban",
     "wof:parent_id":85679765,
     "wof:placetype":"county",

--- a/data/110/869/313/5/1108693135.geojson
+++ b/data/110/869/313/5/1108693135.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.282664,
-    "geom:area_square_m":3451726144.924033,
+    "geom:area_square_m":3451725431.090078,
     "geom:bbox":"34.272464,-9.443814,34.895114,-8.663164",
     "geom:latitude":-9.04316,
     "geom:longitude":34.56889,
@@ -57,7 +57,7 @@
     "wof:concordances":{},
     "wof:country":"TZ",
     "wof:created":1474327073,
-    "wof:geomhash":"b500f9d671b2cbd3d2fff604cbcea033",
+    "wof:geomhash":"efbb2404af9bcf2d13dde004d0330e85",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -67,7 +67,7 @@
         }
     ],
     "wof:id":1108693135,
-    "wof:lastmodified":1627522879,
+    "wof:lastmodified":1695886035,
     "wof:name":"Wanging'ombe",
     "wof:parent_id":85679765,
     "wof:placetype":"county",

--- a/data/110/869/313/7/1108693137.geojson
+++ b/data/110/869/313/7/1108693137.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.328812,
-    "geom:area_square_m":4013227851.043021,
+    "geom:area_square_m":4013228736.325691,
     "geom:bbox":"33.810973,-9.708548,34.483399,-8.838471",
     "geom:latitude":-9.223481,
     "geom:longitude":34.146412,
@@ -100,9 +100,10 @@
         "hasc:id":"TZ.NJ.MA",
         "wd:id":"Q1143905"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TZ",
     "wof:created":1474327074,
-    "wof:geomhash":"9ed3a300338f8e12c22df47ae24145eb",
+    "wof:geomhash":"c79e4e7be368a4ba367c7fd83854a6fa",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -112,7 +113,7 @@
         }
     ],
     "wof:id":1108693137,
-    "wof:lastmodified":1690876110,
+    "wof:lastmodified":1695886583,
     "wof:name":"Makete",
     "wof:parent_id":85679765,
     "wof:placetype":"county",

--- a/data/110/869/313/9/1108693139.geojson
+++ b/data/110/869/313/9/1108693139.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.284208,
-    "geom:area_square_m":3468817772.020087,
+    "geom:area_square_m":3468817927.268151,
     "geom:bbox":"34.753044,-9.647761,35.523169,-8.920829",
     "geom:latitude":-9.225419,
     "geom:longitude":35.18956,
@@ -74,9 +74,10 @@
         "hasc:id":"TZ.IR.NJ",
         "wd:id":"Q846037"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TZ",
     "wof:created":1474327076,
-    "wof:geomhash":"4e930a1896f13c8013b9a8cdb847ea2b",
+    "wof:geomhash":"94357d4d8e61277ef9f049a0637032d0",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -86,7 +87,7 @@
         }
     ],
     "wof:id":1108693139,
-    "wof:lastmodified":1627522873,
+    "wof:lastmodified":1695886028,
     "wof:name":"Njombe Rural",
     "wof:parent_id":85679765,
     "wof:placetype":"county",

--- a/data/110/869/314/1/1108693141.geojson
+++ b/data/110/869/314/1/1108693141.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.490889,
-    "geom:area_square_m":5977508405.946546,
+    "geom:area_square_m":5977509537.434788,
     "geom:bbox":"34.073153,-10.538403,35.218649,-9.507574",
     "geom:latitude":-10.009269,
     "geom:longitude":34.765738,
@@ -97,9 +97,10 @@
         "hasc:id":"TZ.NJ.LU",
         "wd:id":"Q441811"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TZ",
     "wof:created":1474327077,
-    "wof:geomhash":"a8bafa3d3ab1503aca56b97e9cffa9c1",
+    "wof:geomhash":"e7ee2bdeadcc323eefb7a89875101d2b",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -109,7 +110,7 @@
         }
     ],
     "wof:id":1108693141,
-    "wof:lastmodified":1690876110,
+    "wof:lastmodified":1695886582,
     "wof:name":"Ludewa",
     "wof:parent_id":85679765,
     "wof:placetype":"county",

--- a/data/110/869/314/5/1108693145.geojson
+++ b/data/110/869/314/5/1108693145.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.072626,
-    "geom:area_square_m":887212620.625857,
+    "geom:area_square_m":887212616.952169,
     "geom:bbox":"34.687614,-9.03434,35.144915,-8.769074",
     "geom:latitude":-8.901709,
     "geom:longitude":34.947182,
@@ -54,7 +54,7 @@
     "wof:concordances":{},
     "wof:country":"TZ",
     "wof:created":1474327079,
-    "wof:geomhash":"f078375d71d26cc4e8a16ea46e0ce022",
+    "wof:geomhash":"050a70565f4af20f36fbe3174d2638d0",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -64,7 +64,7 @@
         }
     ],
     "wof:id":1108693145,
-    "wof:lastmodified":1627522866,
+    "wof:lastmodified":1695886583,
     "wof:name":"Makambako Township Authority",
     "wof:parent_id":85679765,
     "wof:placetype":"county",

--- a/data/110/869/314/7/1108693147.geojson
+++ b/data/110/869/314/7/1108693147.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.026029,
-    "geom:area_square_m":319837547.204141,
+    "geom:area_square_m":319837693.829374,
     "geom:bbox":"30.846712,-6.542715,31.131198,-6.275439",
     "geom:latitude":-6.410213,
     "geom:longitude":30.990148,
@@ -54,7 +54,7 @@
     "wof:concordances":{},
     "wof:country":"TZ",
     "wof:created":1474327080,
-    "wof:geomhash":"a5a7a5d48e5e0d5eff12c3d086a9ea70",
+    "wof:geomhash":"a56edce8412e5e2990f57121e17b2d5d",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -64,7 +64,7 @@
         }
     ],
     "wof:id":1108693147,
-    "wof:lastmodified":1627522870,
+    "wof:lastmodified":1695886590,
     "wof:name":"Mpanda Urban",
     "wof:parent_id":85679751,
     "wof:placetype":"county",

--- a/data/110/869/314/9/1108693149.geojson
+++ b/data/110/869/314/9/1108693149.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.383639,
-    "geom:area_square_m":17016427968.309845,
+    "geom:area_square_m":17016427331.133263,
     "geom:bbox":"29.903001,-6.937128,31.186918,-5.133377",
     "geom:latitude":-5.942623,
     "geom:longitude":30.600203,
@@ -54,9 +54,10 @@
     "wof:concordances":{
         "hasc:id":"TZ.RK.MP"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TZ",
     "wof:created":1474327082,
-    "wof:geomhash":"c83608ea65432ca0df60df0ac1514586",
+    "wof:geomhash":"c3cfd529a4296f603a995159843b92b3",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -66,7 +67,7 @@
         }
     ],
     "wof:id":1108693149,
-    "wof:lastmodified":1627522870,
+    "wof:lastmodified":1695886590,
     "wof:name":"Mpanda Rural",
     "wof:parent_id":85679751,
     "wof:placetype":"county",

--- a/data/110/869/315/1/1108693151.geojson
+++ b/data/110/869/315/1/1108693151.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.422712,
-    "geom:area_square_m":29755575262.020367,
+    "geom:area_square_m":29755575843.765804,
     "geom:bbox":"30.926252,-7.611911,32.758813,-5.607114",
     "geom:latitude":-6.63779,
     "geom:longitude":31.775404,
@@ -77,7 +77,7 @@
     },
     "wof:country":"TZ",
     "wof:created":1474327083,
-    "wof:geomhash":"aba772210893b6d47ed8e86b32bd0c71",
+    "wof:geomhash":"51ca4af3dcaa9c67552d4261857a642f",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -87,7 +87,7 @@
         }
     ],
     "wof:id":1108693151,
-    "wof:lastmodified":1690876109,
+    "wof:lastmodified":1695886589,
     "wof:name":"Mlele",
     "wof:parent_id":85679751,
     "wof:placetype":"county",

--- a/data/110/869/315/3/1108693153.geojson
+++ b/data/110/869/315/3/1108693153.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.381469,
-    "geom:area_square_m":4711102236.504322,
+    "geom:area_square_m":4711101485.031426,
     "geom:bbox":"33.651003,-3.104193,35.194691,-2.671208",
     "geom:latitude":-2.84943,
     "geom:longitude":34.467018,
@@ -54,7 +54,7 @@
     "wof:concordances":{},
     "wof:country":"TZ",
     "wof:created":1474327085,
-    "wof:geomhash":"ae83fb5f17ba06a5fc6681ce128df916",
+    "wof:geomhash":"3dcc2a02ad1e34f4623553f333f87f44",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -64,7 +64,7 @@
         }
     ],
     "wof:id":1108693153,
-    "wof:lastmodified":1627522861,
+    "wof:lastmodified":1695886575,
     "wof:name":"Itilima",
     "wof:parent_id":85679755,
     "wof:placetype":"county",

--- a/data/110/869/315/5/1108693155.geojson
+++ b/data/110/869/315/5/1108693155.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.733961,
-    "geom:area_square_m":9059077770.130095,
+    "geom:area_square_m":9059078321.359629,
     "geom:bbox":"34.045801,-4.084633,34.890997,-2.928766",
     "geom:latitude":-3.44321,
     "geom:longitude":34.473886,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"TZ.SI.ME"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TZ",
     "wof:created":1474327087,
-    "wof:geomhash":"4a62af14094ea832643206eed8e75194",
+    "wof:geomhash":"18e41a244c9c7173c675499919138757",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1108693155,
-    "wof:lastmodified":1627522867,
+    "wof:lastmodified":1695886585,
     "wof:name":"Meatu",
     "wof:parent_id":85679755,
     "wof:placetype":"county",

--- a/data/110/869/315/7/1108693157.geojson
+++ b/data/110/869/315/7/1108693157.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.298372,
-    "geom:area_square_m":3683549227.430744,
+    "geom:area_square_m":3683549523.995307,
     "geom:bbox":"33.423074,-3.604221,34.149794,-2.79965",
     "geom:latitude":-3.230173,
     "geom:longitude":33.788058,
@@ -88,9 +88,10 @@
         "hasc:id":"TZ.SI.MA",
         "wd:id":"Q6785741"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TZ",
     "wof:created":1474327089,
-    "wof:geomhash":"4e80789c45d3e5321e255432d0cd2b0e",
+    "wof:geomhash":"00d89106bf12ea0fe3a955d4f4d50ed0",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -100,7 +101,7 @@
         }
     ],
     "wof:id":1108693157,
-    "wof:lastmodified":1690876108,
+    "wof:lastmodified":1695886583,
     "wof:name":"Maswa",
     "wof:parent_id":85679755,
     "wof:placetype":"county",

--- a/data/110/869/315/9/1108693159.geojson
+++ b/data/110/869/315/9/1108693159.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.107977,
-    "geom:area_square_m":1333993615.50547,
+    "geom:area_square_m":1333993799.325665,
     "geom:bbox":"33.496027,-2.575013,34.025656,-2.178633",
     "geom:latitude":-2.389581,
     "geom:longitude":33.777735,
@@ -54,7 +54,7 @@
     "wof:concordances":{},
     "wof:country":"TZ",
     "wof:created":1474327090,
-    "wof:geomhash":"4f882786725a2a80dfaabb543531be50",
+    "wof:geomhash":"f3a656c8ad13aca6b4ec10e9cc12b2ec",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -64,7 +64,7 @@
         }
     ],
     "wof:id":1108693159,
-    "wof:lastmodified":1642551824,
+    "wof:lastmodified":1695886535,
     "wof:name":"Busega",
     "wof:parent_id":85679755,
     "wof:placetype":"county",

--- a/data/110/869/316/3/1108693163.geojson
+++ b/data/110/869/316/3/1108693163.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.382901,
-    "geom:area_square_m":4728690639.060064,
+    "geom:area_square_m":4728689991.832056,
     "geom:bbox":"31.773745,-3.326932,32.583297,-2.237867",
     "geom:latitude":-2.86752,
     "geom:longitude":32.174217,
@@ -109,9 +109,10 @@
         "hasc:id":"TZ.GE.GE",
         "wd:id":"Q1884330"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TZ",
     "wof:created":1474327092,
-    "wof:geomhash":"49fc1d614416b42271387d5ea068451e",
+    "wof:geomhash":"c72134d78b862509afadcad1cf306ea8",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -121,7 +122,7 @@
         }
     ],
     "wof:id":1108693163,
-    "wof:lastmodified":1690876118,
+    "wof:lastmodified":1695886784,
     "wof:name":"Geita",
     "wof:parent_id":85679761,
     "wof:placetype":"county",

--- a/data/110/869/316/5/1108693165.geojson
+++ b/data/110/869/316/5/1108693165.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.130712,
-    "geom:area_square_m":1613838915.240389,
+    "geom:area_square_m":1613839540.350504,
     "geom:bbox":"32.382301,-3.457163,32.792927,-2.899108",
     "geom:latitude":-3.14955,
     "geom:longitude":32.604833,
@@ -81,7 +81,7 @@
     },
     "wof:country":"TZ",
     "wof:created":1474327093,
-    "wof:geomhash":"722242812b613ba38947944ee5b8c870",
+    "wof:geomhash":"c18018988ec5db53a9c59689882bda71",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -91,7 +91,7 @@
         }
     ],
     "wof:id":1108693165,
-    "wof:lastmodified":1690876119,
+    "wof:lastmodified":1695886027,
     "wof:name":"Nyang'wale",
     "wof:parent_id":85679761,
     "wof:placetype":"county",

--- a/data/110/869/316/7/1108693167.geojson
+++ b/data/110/869/316/7/1108693167.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.185637,
-    "geom:area_square_m":2291238476.842424,
+    "geom:area_square_m":2291237894.961481,
     "geom:bbox":"31.837737,-3.813611,32.415505,-3.125979",
     "geom:latitude":-3.462603,
     "geom:longitude":32.161057,
@@ -54,7 +54,7 @@
     "wof:concordances":{},
     "wof:country":"TZ",
     "wof:created":1474327095,
-    "wof:geomhash":"c4e066e0931259925cace801b04abf88",
+    "wof:geomhash":"c8e67c9875d508ccfc571161679c5c62",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -64,7 +64,7 @@
         }
     ],
     "wof:id":1108693167,
-    "wof:lastmodified":1627522867,
+    "wof:lastmodified":1695886585,
     "wof:name":"Mbogwe",
     "wof:parent_id":85679761,
     "wof:placetype":"county",

--- a/data/110/869/316/9/1108693169.geojson
+++ b/data/110/869/316/9/1108693169.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.655788,
-    "geom:area_square_m":8091852734.411715,
+    "geom:area_square_m":8091852694.060662,
     "geom:bbox":"31.149676,-4.469112,32.157356,-3.107642",
     "geom:latitude":-3.708197,
     "geom:longitude":31.605487,
@@ -91,9 +91,10 @@
         "hasc:id":"TZ.GE.BU",
         "wd:id":"Q4987002"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TZ",
     "wof:created":1474327096,
-    "wof:geomhash":"d54816e5e5f9369a8ef2c0d63c5758dd",
+    "wof:geomhash":"2c1d004425cfdaf1d27203b661e267fa",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -103,7 +104,7 @@
         }
     ],
     "wof:id":1108693169,
-    "wof:lastmodified":1690876118,
+    "wof:lastmodified":1695886675,
     "wof:name":"Bukombe",
     "wof:parent_id":85679761,
     "wof:placetype":"county",

--- a/data/110/869/317/1/1108693171.geojson
+++ b/data/110/869/317/1/1108693171.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.25006,
-    "geom:area_square_m":3088201546.415627,
+    "geom:area_square_m":3088202014.945668,
     "geom:bbox":"31.402934,-3.396644,31.93012,-2.293049",
     "geom:latitude":-2.84248,
     "geom:longitude":31.681623,
@@ -66,7 +66,7 @@
     "wof:concordances":{},
     "wof:country":"TZ",
     "wof:created":1474327098,
-    "wof:geomhash":"d1526285b1620217b716a0edd31f6cdb",
+    "wof:geomhash":"d39348a948ee2352340253d999031174",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -76,7 +76,7 @@
         }
     ],
     "wof:id":1108693171,
-    "wof:lastmodified":1627522858,
+    "wof:lastmodified":1695886571,
     "wof:name":"Chato",
     "wof:parent_id":85679761,
     "wof:placetype":"county",

--- a/data/110/869/317/3/1108693173.geojson
+++ b/data/110/869/317/3/1108693173.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001263,
-    "geom:area_square_m":15524665.162793,
+    "geom:area_square_m":15524654.060365,
     "geom:bbox":"39.185588,-6.195518,39.226766,-6.137908",
     "geom:latitude":-6.166239,
     "geom:longitude":39.209399,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"TZ.ZW.TO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TZ",
     "wof:created":1474327104,
-    "wof:geomhash":"ddd0812060de56b88c023a4cb63b0d80",
+    "wof:geomhash":"47c5bb2a45c884e555f0afe0e8c4c2c5",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1108693173,
-    "wof:lastmodified":1627522868,
+    "wof:lastmodified":1695886586,
     "wof:name":"Mjini",
     "wof:parent_id":85679699,
     "wof:placetype":"county",

--- a/data/110/869/317/5/1108693175.geojson
+++ b/data/110/869/317/5/1108693175.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.02089,
-    "geom:area_square_m":257170164.822276,
+    "geom:area_square_m":257170177.867379,
     "geom:bbox":"39.56271,-5.487027,39.809722,-5.281792",
     "geom:latitude":-5.380464,
     "geom:longitude":39.706554,
@@ -99,9 +99,10 @@
     "wof:concordances":{
         "hasc:id":"TZ.PS.MK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TZ",
     "wof:created":1474327109,
-    "wof:geomhash":"2e6feccef654e0f501a287af9010e710",
+    "wof:geomhash":"cc3f009e1236a52e00b012d96a7d4c77",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -111,7 +112,7 @@
         }
     ],
     "wof:id":1108693175,
-    "wof:lastmodified":1627522868,
+    "wof:lastmodified":1695886586,
     "wof:name":"Mkoani",
     "wof:parent_id":85679687,
     "wof:placetype":"county",

--- a/data/421/170/113/421170113.geojson
+++ b/data/421/170/113/421170113.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.02076,
-    "geom:area_square_m":253618336.302541,
+    "geom:area_square_m":253618140.718348,
     "geom:bbox":"33.360654,-8.979302,33.589989,-8.830657",
     "geom:latitude":-8.897832,
     "geom:longitude":33.47738,
@@ -115,12 +115,13 @@
         "qs_pg:id":218429,
         "wd:id":"Q6799690"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TZ",
     "wof:created":1459008837,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"2bb65d7ea8cada9d0ac86ca7f27b8168",
+    "wof:geomhash":"7081c53313695b76d49b108e4724c845",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -130,7 +131,7 @@
         }
     ],
     "wof:id":421170113,
-    "wof:lastmodified":1690876140,
+    "wof:lastmodified":1695886583,
     "wof:name":"Mbeya Urban",
     "wof:parent_id":85679641,
     "wof:placetype":"county",

--- a/data/421/170/243/421170243.geojson
+++ b/data/421/170/243/421170243.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.906956,
-    "geom:area_square_m":11207741167.29051,
+    "geom:area_square_m":11207741566.633398,
     "geom:bbox":"34.215418,-2.498291,35.265917,-1.416299",
     "geom:latitude":-1.997656,
     "geom:longitude":34.744067,
@@ -117,12 +117,13 @@
         "wd:id":"Q7193912",
         "wk:page":"Serengeti District"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TZ",
     "wof:created":1459008845,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"4dee2e475e667128451f4c9d948cc08e",
+    "wof:geomhash":"9b6e7d0d50b5ee66bbbeb331995a2b93",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -132,7 +133,7 @@
         }
     ],
     "wof:id":421170243,
-    "wof:lastmodified":1690876139,
+    "wof:lastmodified":1695886031,
     "wof:name":"Serengeti",
     "wof:parent_id":85679743,
     "wof:placetype":"county",

--- a/data/421/171/039/421171039.geojson
+++ b/data/421/171/039/421171039.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.299441,
-    "geom:area_square_m":3691086180.042863,
+    "geom:area_square_m":3691085609.666022,
     "geom:bbox":"34.86441,-4.876764,35.66477,-4.242558",
     "geom:latitude":-4.527474,
     "geom:longitude":35.30005,
@@ -117,12 +117,13 @@
         "wd:id":"Q1888301",
         "wk:page":"Hanang District"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TZ",
     "wof:created":1459008879,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"74e8fba62d15d6979d58e00d829ee905",
+    "wof:geomhash":"a1017eda1b41b10762cbd7ae4da7d1b8",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -132,7 +133,7 @@
         }
     ],
     "wof:id":421171039,
-    "wof:lastmodified":1690876144,
+    "wof:lastmodified":1695886571,
     "wof:name":"Hanang",
     "wof:parent_id":85679733,
     "wof:placetype":"county",

--- a/data/421/171/043/421171043.geojson
+++ b/data/421/171/043/421171043.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.109523,
-    "geom:area_square_m":1351920368.983311,
+    "geom:area_square_m":1351920172.592007,
     "geom:bbox":"37.248947,-3.648024,37.615524,-3.091511",
     "geom:latitude":-3.376007,
     "geom:longitude":37.421,
@@ -106,12 +106,13 @@
         "wd:id":"Q6916218",
         "wk:page":"Moshi District"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TZ",
     "wof:created":1459008879,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"75ae0334cc48951872c5266288eb212d",
+    "wof:geomhash":"bc83764c51590bfffa4512a68617deba",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -121,7 +122,7 @@
         }
     ],
     "wof:id":421171043,
-    "wof:lastmodified":1690876145,
+    "wof:lastmodified":1695886509,
     "wof:name":"Moshi",
     "wof:parent_id":85679737,
     "wof:placetype":"county",

--- a/data/421/171/979/421171979.geojson
+++ b/data/421/171/979/421171979.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.293871,
-    "geom:area_square_m":15981066624.181564,
+    "geom:area_square_m":15981066854.341011,
     "geom:bbox":"34.880811,-3.621804,36.130013,-1.686907",
     "geom:latitude":-2.672196,
     "geom:longitude":35.49482,
@@ -156,12 +156,13 @@
         "wd:id":"Q2559572",
         "wk:page":"Ngorongoro District"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TZ",
     "wof:created":1459008914,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"30a33d505fc8560d964af0b6193f94f1",
+    "wof:geomhash":"9f670453155bc2e4464551c25ac89400",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -171,7 +172,7 @@
         }
     ],
     "wof:id":421171979,
-    "wof:lastmodified":1690876144,
+    "wof:lastmodified":1695886788,
     "wof:name":"Ngorongoro",
     "wof:parent_id":85679731,
     "wof:placetype":"county",

--- a/data/421/171/981/421171981.geojson
+++ b/data/421/171/981/421171981.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.119613,
-    "geom:area_square_m":1476876788.891124,
+    "geom:area_square_m":1476876585.28226,
     "geom:bbox":"37.250329,-3.403258,37.710573,-2.849604",
     "geom:latitude":-3.092937,
     "geom:longitude":37.490285,
@@ -111,12 +111,13 @@
         "wd:id":"Q1365107",
         "wk:page":"Rombo District"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TZ",
     "wof:created":1459008914,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"e4c2d5a569a32f5689f4bc1b5f7c7bda",
+    "wof:geomhash":"562c1e12083f5ef3c24d050b15557e28",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -126,7 +127,7 @@
         }
     ],
     "wof:id":421171981,
-    "wof:lastmodified":1690876145,
+    "wof:lastmodified":1695886789,
     "wof:name":"Rombo",
     "wof:parent_id":85679737,
     "wof:placetype":"county",

--- a/data/421/175/227/421175227.geojson
+++ b/data/421/175/227/421175227.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.100677,
-    "geom:area_square_m":1242765750.630273,
+    "geom:area_square_m":1242765049.642677,
     "geom:bbox":"36.468999,-3.65315,36.888238,-3.06394",
     "geom:latitude":-3.345523,
     "geom:longitude":36.687354,
@@ -126,12 +126,13 @@
         "wd:id":"Q2559662",
         "wk:page":"Arusha District"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TZ",
     "wof:created":1459009060,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"2358f0e2c59af0a00a030afc48dba9aa",
+    "wof:geomhash":"209a1dab8e655a369de301b7ccb88d1f",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -141,7 +142,7 @@
         }
     ],
     "wof:id":421175227,
-    "wof:lastmodified":1690876133,
+    "wof:lastmodified":1695886785,
     "wof:name":"Arusha",
     "wof:parent_id":85679731,
     "wof:placetype":"county",

--- a/data/421/175/229/421175229.geojson
+++ b/data/421/175/229/421175229.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.333433,
-    "geom:area_square_m":4109947679.675257,
+    "geom:area_square_m":4109949033.027227,
     "geom:bbox":"38.115186,-4.98352,38.759904,-4.10869",
     "geom:latitude":-4.549834,
     "geom:longitude":38.440527,
@@ -116,12 +116,13 @@
         "qs_pg:id":361748,
         "wd:id":"Q1877698"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TZ",
     "wof:created":1459009060,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"f4ebf2d458d514a04b344baa36792fdd",
+    "wof:geomhash":"18fb377d7615da14dd4e356f204fc37d",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -131,7 +132,7 @@
         }
     ],
     "wof:id":421175229,
-    "wof:lastmodified":1690876133,
+    "wof:lastmodified":1695886580,
     "wof:name":"Lushoto",
     "wof:parent_id":85679747,
     "wof:placetype":"county",

--- a/data/421/175/441/421175441.geojson
+++ b/data/421/175/441/421175441.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.124698,
-    "geom:area_square_m":1541453864.505468,
+    "geom:area_square_m":1541453788.085105,
     "geom:bbox":"34.164187,-1.605831,34.783026,-1.186327",
     "geom:latitude":-1.392734,
     "geom:longitude":34.467131,
@@ -120,12 +120,13 @@
         "wd:id":"Q7194958",
         "wk:page":"Tarime District"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TZ",
     "wof:created":1459009067,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"e937ccc515615ff4874fc47d892e8868",
+    "wof:geomhash":"51860add421048d202b1bc6d4c42eb01",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -135,7 +136,7 @@
         }
     ],
     "wof:id":421175441,
-    "wof:lastmodified":1690876133,
+    "wof:lastmodified":1695886032,
     "wof:name":"Tarime",
     "wof:parent_id":85679743,
     "wof:placetype":"county",

--- a/data/421/178/387/421178387.geojson
+++ b/data/421/178/387/421178387.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.614492,
-    "geom:area_square_m":19906358002.838379,
+    "geom:area_square_m":19906358109.411053,
     "geom:bbox":"36.290855,-5.193215,38.000054,-3.448487",
     "geom:latitude":-4.316191,
     "geom:longitude":37.091043,
@@ -118,12 +118,13 @@
         "qs_pg:id":117128,
         "wd:id":"Q1888312"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TZ",
     "wof:created":1459009180,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"c94d67fc683343c1251caa586c420071",
+    "wof:geomhash":"ce25f4cb41db5d75ed8fe0a2a5d3eb90",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -133,7 +134,7 @@
         }
     ],
     "wof:id":421178387,
-    "wof:lastmodified":1690876143,
+    "wof:lastmodified":1695886031,
     "wof:name":"Simanjiro",
     "wof:parent_id":85679733,
     "wof:placetype":"county",

--- a/data/421/180/247/421180247.geojson
+++ b/data/421/180/247/421180247.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.078876,
-    "geom:area_square_m":972011404.431798,
+    "geom:area_square_m":972010889.950114,
     "geom:bbox":"29.598407,-4.95784,29.988831,-4.443656",
     "geom:latitude":-4.719504,
     "geom:longitude":29.741811,
@@ -92,12 +92,13 @@
         "hasc:id":"TZ.KM.KR",
         "qs_pg:id":424742
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TZ",
     "wof:created":1459009249,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"5a936ea2f96c046174574d2b4225bb3c",
+    "wof:geomhash":"8630554f5a0a5463a57221c3d01eb3ab",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -107,7 +108,7 @@
         }
     ],
     "wof:id":421180247,
-    "wof:lastmodified":1627522862,
+    "wof:lastmodified":1695886576,
     "wof:name":"Kigoma Rural",
     "wof:parent_id":85679669,
     "wof:placetype":"county",

--- a/data/421/182/255/421182255.geojson
+++ b/data/421/182/255/421182255.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.045363,
-    "geom:area_square_m":12802121697.490126,
+    "geom:area_square_m":12802121126.50243,
     "geom:bbox":"37.794138,-8.512519,39.446613,-7.470222",
     "geom:latitude":-7.93905,
     "geom:longitude":38.62841,
@@ -125,12 +125,13 @@
         "hasc:id":"TZ.PW.RU",
         "qs_pg:id":896708
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TZ",
     "wof:created":1459009323,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"f7b88bbf6668e6732f81e1e69400c89c",
+    "wof:geomhash":"40472fa9508c4905ada2b3d9a035856a",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -140,7 +141,7 @@
         }
     ],
     "wof:id":421182255,
-    "wof:lastmodified":1636501541,
+    "wof:lastmodified":1695886786,
     "wof:name":"Rufiji",
     "wof:parent_id":85679691,
     "wof:placetype":"county",

--- a/data/421/183/841/421183841.geojson
+++ b/data/421/183/841/421183841.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.231511,
-    "geom:area_square_m":2839645287.516618,
+    "geom:area_square_m":2839645487.393897,
     "geom:bbox":"38.822129,-7.550489,39.450601,-6.941711",
     "geom:latitude":-7.271197,
     "geom:longitude":39.158009,
@@ -91,12 +91,13 @@
         "hasc:id":"TZ.PW.MK",
         "qs_pg:id":984968
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TZ",
     "wof:created":1459009389,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"9c191d5da77f2a6067489c22a8e9b8d3",
+    "wof:geomhash":"13835b6b38a0ff6601e2c06522c69bd6",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -106,7 +107,7 @@
         }
     ],
     "wof:id":421183841,
-    "wof:lastmodified":1627522869,
+    "wof:lastmodified":1695886588,
     "wof:name":"Mkuranga",
     "wof:parent_id":85679691,
     "wof:placetype":"county",

--- a/data/421/186/277/421186277.geojson
+++ b/data/421/186/277/421186277.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.365093,
-    "geom:area_square_m":29060793784.837898,
+    "geom:area_square_m":29060791764.433823,
     "geom:bbox":"33.486549,-7.534773,35.356383,-5.277075",
     "geom:latitude":-6.411144,
     "geom:longitude":34.451358,
@@ -183,12 +183,13 @@
         "qs_pg:id":1063167,
         "wd:id":"Q6753411"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TZ",
     "wof:created":1459009476,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"3b77ef41d3de861af1ef66467b3e879b",
+    "wof:geomhash":"379c5ce517afe72932cab5009ae3a85e",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -198,7 +199,7 @@
         }
     ],
     "wof:id":421186277,
-    "wof:lastmodified":1690876132,
+    "wof:lastmodified":1695886785,
     "wof:name":"Manyoni",
     "wof:parent_id":85679727,
     "wof:placetype":"county",

--- a/data/421/187/711/421187711.geojson
+++ b/data/421/187/711/421187711.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.263536,
-    "geom:area_square_m":3252392162.459536,
+    "geom:area_square_m":3252392919.939317,
     "geom:bbox":"34.749262,-3.944438,35.975552,-3.029767",
     "geom:latitude":-3.552118,
     "geom:longitude":35.434329,
@@ -127,12 +127,13 @@
         "qs_pg:id":7343,
         "wd:id":"Q940198"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TZ",
     "wof:created":1459009521,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"2eefd636a49ae1f3cb093e912ab82ce2",
+    "wof:geomhash":"eea9b32877244650aa9304e768dcb4b0",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -142,7 +143,7 @@
         }
     ],
     "wof:id":421187711,
-    "wof:lastmodified":1690876129,
+    "wof:lastmodified":1695886788,
     "wof:name":"Karatu",
     "wof:parent_id":85679731,
     "wof:placetype":"county",

--- a/data/421/187/951/421187951.geojson
+++ b/data/421/187/951/421187951.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.446007,
-    "geom:area_square_m":5509394575.092847,
+    "geom:area_square_m":5509394205.860801,
     "geom:bbox":"33.622897,-2.995142,35.223437,-2.205902",
     "geom:latitude":-2.573212,
     "geom:longitude":34.307975,
@@ -129,12 +129,13 @@
         "wd:id":"Q4624506",
         "wk:page":"Bariadi"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TZ",
     "wof:created":1459009529,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"3b7eb1c0d5dc3d441052a430ba057a34",
+    "wof:geomhash":"5bafc14082b464381cf6a570db9bf72a",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -144,7 +145,7 @@
         }
     ],
     "wof:id":421187951,
-    "wof:lastmodified":1690876129,
+    "wof:lastmodified":1695886788,
     "wof:name":"Bariadi",
     "wof:parent_id":85679755,
     "wof:placetype":"county",

--- a/data/421/187/953/421187953.geojson
+++ b/data/421/187/953/421187953.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.251426,
-    "geom:area_square_m":3106956368.889656,
+    "geom:area_square_m":3106955989.096961,
     "geom:bbox":"33.202932,-2.298777,34.322421,-1.772967",
     "geom:latitude":-2.037595,
     "geom:longitude":33.89772,
@@ -126,12 +126,13 @@
         "wd:id":"Q1888276",
         "wk:page":"Bunda District"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TZ",
     "wof:created":1459009529,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"69da4731ac23323075f796e9d4479d4d",
+    "wof:geomhash":"dba45305454460ea27fca285b45ea0b6",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -141,7 +142,7 @@
         }
     ],
     "wof:id":421187953,
-    "wof:lastmodified":1690876128,
+    "wof:lastmodified":1695886569,
     "wof:name":"Bunda",
     "wof:parent_id":85679743,
     "wof:placetype":"county",

--- a/data/421/187/955/421187955.geojson
+++ b/data/421/187/955/421187955.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.017873,
-    "geom:area_square_m":220081543.661037,
+    "geom:area_square_m":220081467.055514,
     "geom:bbox":"39.647472,-5.335593,39.855784,-5.15853",
     "geom:latitude":-5.24984,
     "geom:longitude":39.770848,
@@ -131,12 +131,13 @@
         "hasc:id":"TZ.PS.CH",
         "qs_pg:id":1086847
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TZ",
     "wof:created":1459009529,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"9019ab9d8aecae7bcb82123308fcab7e",
+    "wof:geomhash":"5242ffe61742ef37aea1c76cb556ca85",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -146,7 +147,7 @@
         }
     ],
     "wof:id":421187955,
-    "wof:lastmodified":1636501536,
+    "wof:lastmodified":1695886785,
     "wof:name":"Chake Chake",
     "wof:parent_id":85679687,
     "wof:placetype":"county",

--- a/data/421/187/957/421187957.geojson
+++ b/data/421/187/957/421187957.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.21302,
-    "geom:area_square_m":2619088385.88439,
+    "geom:area_square_m":2619088411.160419,
     "geom:bbox":"35.479494,-6.463677,36.133773,-5.828012",
     "geom:latitude":-6.105878,
     "geom:longitude":35.791215,
@@ -123,12 +123,13 @@
         "wd:id":"Q3710545",
         "wk:page":"Dodoma District"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TZ",
     "wof:created":1459009529,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"23881c700f5b5f83d96614a64093b7ae",
+    "wof:geomhash":"75257179816db4c5b949b219f5d4f08f",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -138,7 +139,7 @@
         }
     ],
     "wof:id":421187957,
-    "wof:lastmodified":1690876128,
+    "wof:lastmodified":1695886572,
     "wof:name":"Dodoma Urban",
     "wof:parent_id":85679705,
     "wof:placetype":"county",

--- a/data/421/187/959/421187959.geojson
+++ b/data/421/187/959/421187959.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.538936,
-    "geom:area_square_m":18866081258.122009,
+    "geom:area_square_m":18866080676.852505,
     "geom:bbox":"34.193339,-8.242106,36.200946,-6.886497",
     "geom:latitude":-7.502077,
     "geom:longitude":35.195316,
@@ -117,12 +117,13 @@
         "qs_pg:id":1086849,
         "wd:id":"Q1888339"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TZ",
     "wof:created":1459009529,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"ddd59790032a2b0811b70b5e17bb2283",
+    "wof:geomhash":"e8a7132e0ba9a3d99c89e782f1aed8ab",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -132,7 +133,7 @@
         }
     ],
     "wof:id":421187959,
-    "wof:lastmodified":1690876129,
+    "wof:lastmodified":1695886573,
     "wof:name":"Iringa Rural",
     "wof:parent_id":85679711,
     "wof:placetype":"county",

--- a/data/421/187/961/421187961.geojson
+++ b/data/421/187/961/421187961.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.233793,
-    "geom:area_square_m":15063400871.762012,
+    "geom:area_square_m":15063400856.563099,
     "geom:bbox":"38.436247,-9.920367,39.663797,-8.257188",
     "geom:latitude":-9.108351,
     "geom:longitude":39.016196,
@@ -132,12 +132,13 @@
         "wd:id":"Q2221197",
         "wk:page":"Kilwa District"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TZ",
     "wof:created":1459009529,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"143ff0f79e5d0b3ccd22b112e77fd35f",
+    "wof:geomhash":"940433acf2ee2d495ec389f25d905d34",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -147,7 +148,7 @@
         }
     ],
     "wof:id":421187961,
-    "wof:lastmodified":1690876128,
+    "wof:lastmodified":1695886788,
     "wof:name":"Kilwa",
     "wof:parent_id":85679713,
     "wof:placetype":"county",

--- a/data/421/188/197/421188197.geojson
+++ b/data/421/188/197/421188197.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.031013,
-    "geom:area_square_m":381132342.209794,
+    "geom:area_square_m":381132279.1991,
     "geom:bbox":"39.388633,-6.478158,39.580349,-6.175818",
     "geom:latitude":-6.338447,
     "geom:longitude":39.492968,
@@ -91,12 +91,13 @@
         "hasc:id":"TZ.ZS.SO",
         "qs_pg:id":1090326
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TZ",
     "wof:created":1459009537,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"42ea4edbb329362053c234209cfd6eac",
+    "wof:geomhash":"9fa3c00e4a3a4327ecc6a90318921408",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -106,7 +107,7 @@
         }
     ],
     "wof:id":421188197,
-    "wof:lastmodified":1627522864,
+    "wof:lastmodified":1695886579,
     "wof:name":"Kusini",
     "wof:parent_id":85679651,
     "wof:placetype":"county",

--- a/data/421/188/919/421188919.geojson
+++ b/data/421/188/919/421188919.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.08697,
-    "geom:area_square_m":1074839314.988366,
+    "geom:area_square_m":1074838798.393161,
     "geom:bbox":"33.287771,-2.041498,33.777166,-1.609258",
     "geom:latitude":-1.853994,
     "geom:longitude":33.590584,
@@ -179,12 +179,13 @@
         "hasc:id":"TZ.MA.MR",
         "qs_pg:id":1105191
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TZ",
     "wof:created":1459009588,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"836296d77d5d963b0a7b1d5f7165f4ff",
+    "wof:geomhash":"66510bda5ab3d4afd257327a2453ea4a",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -194,7 +195,7 @@
         }
     ],
     "wof:id":421188919,
-    "wof:lastmodified":1636501536,
+    "wof:lastmodified":1695886785,
     "wof:name":"Musoma",
     "wof:parent_id":85679743,
     "wof:placetype":"county",

--- a/data/421/188/923/421188923.geojson
+++ b/data/421/188/923/421188923.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.048649,
-    "geom:area_square_m":599156464.784271,
+    "geom:area_square_m":599156464.784312,
     "geom:bbox":"38.898438135,-5.292823067,39.135625951,-4.959637428",
     "geom:latitude":-5.113995,
     "geom:longitude":39.016292,
@@ -159,12 +159,13 @@
         "hasc:id":"TZ.TN.TA",
         "qs_pg:id":1105192
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TZ",
     "wof:created":1459009588,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"0721adbba08e099497472925fd384878",
+    "wof:geomhash":"4dd2b0b8d916f602a61af95812a53aa7",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -174,7 +175,7 @@
         }
     ],
     "wof:id":421188923,
-    "wof:lastmodified":1582347611,
+    "wof:lastmodified":1695886788,
     "wof:name":"Tanga",
     "wof:parent_id":85679747,
     "wof:placetype":"county",

--- a/data/421/190/259/421190259.geojson
+++ b/data/421/190/259/421190259.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.024061,
-    "geom:area_square_m":296338950.284589,
+    "geom:area_square_m":296339090.427405,
     "geom:bbox":"39.630091,-5.208608,39.872911,-4.974784",
     "geom:latitude":-5.099036,
     "geom:longitude":39.766984,
@@ -153,12 +153,13 @@
         "wd:id":"Q7990058",
         "wk:page":"Wete District"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TZ",
     "wof:created":1459009652,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"88fe4b0095678d1b2dae9f1e121a5374",
+    "wof:geomhash":"0f141f9af8c752489bc7c60018b1f4d2",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -168,7 +169,7 @@
         }
     ],
     "wof:id":421190259,
-    "wof:lastmodified":1690876136,
+    "wof:lastmodified":1695886785,
     "wof:name":"Wete",
     "wof:parent_id":85679683,
     "wof:placetype":"county",

--- a/data/421/191/173/421191173.geojson
+++ b/data/421/191/173/421191173.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.041321,
-    "geom:area_square_m":507985600.491397,
+    "geom:area_square_m":507985835.31876,
     "geom:bbox":"39.269071,-6.392437,39.529236,-6.021441",
     "geom:latitude":-6.163957,
     "geom:longitude":39.370858,
@@ -117,12 +117,13 @@
         "hasc:id":"TZ.ZS.CE",
         "qs_pg:id":7348
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TZ",
     "wof:created":1459009683,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"95495dd8f9ccc2f86220df50d373fac6",
+    "wof:geomhash":"f0687b2a24581f4978065e0e920287bf",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -132,7 +133,7 @@
         }
     ],
     "wof:id":421191173,
-    "wof:lastmodified":1636501538,
+    "wof:lastmodified":1695886786,
     "wof:name":"Kati",
     "wof:parent_id":85679651,
     "wof:placetype":"county",

--- a/data/421/191/925/421191925.geojson
+++ b/data/421/191/925/421191925.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.020707,
-    "geom:area_square_m":255814297.78052,
+    "geom:area_square_m":255814257.585182,
     "geom:bbox":"32.872713,-2.564388,33.156421,-2.255447",
     "geom:latitude":-2.457304,
     "geom:longitude":32.980015,
@@ -114,12 +114,13 @@
         "wd:id":"Q5997545",
         "wk:page":"Ilemela District"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TZ",
     "wof:created":1459009714,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"e94f1212750ac68e6f0a70e2960c89bd",
+    "wof:geomhash":"f17431db0a20003ca156d4d06219d4f7",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -129,7 +130,7 @@
         }
     ],
     "wof:id":421191925,
-    "wof:lastmodified":1690876136,
+    "wof:lastmodified":1695886573,
     "wof:name":"Ilemela",
     "wof:parent_id":85679655,
     "wof:placetype":"county",

--- a/data/421/192/907/421192907.geojson
+++ b/data/421/192/907/421192907.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.411915,
-    "geom:area_square_m":5053096790.859604,
+    "geom:area_square_m":5053096844.960845,
     "geom:bbox":"38.266232,-7.579489,39.11795,-6.784949",
     "geom:latitude":-7.210218,
     "geom:longitude":38.669133,
@@ -117,12 +117,13 @@
         "wd:id":"Q6416417",
         "wk:page":"Kisarawe District"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TZ",
     "wof:created":1459009753,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"8ae981cf1b872fa53c8534efd181d8e8",
+    "wof:geomhash":"fdd97b3f10a267a79774c34a30809b2e",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -132,7 +133,7 @@
         }
     ],
     "wof:id":421192907,
-    "wof:lastmodified":1690876123,
+    "wof:lastmodified":1695886579,
     "wof:name":"Kisarawe",
     "wof:parent_id":85679691,
     "wof:placetype":"county",

--- a/data/421/192/909/421192909.geojson
+++ b/data/421/192/909/421192909.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.062247,
-    "geom:area_square_m":759063509.607298,
+    "geom:area_square_m":759063525.371686,
     "geom:bbox":"33.66816,-9.718722,34.089749,-9.368431",
     "geom:latitude":-9.531766,
     "geom:longitude":33.871108,
@@ -113,12 +113,13 @@
         "qs_pg:id":1182989,
         "wd:id":"Q995244"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TZ",
     "wof:created":1459009753,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"36f927c7edc46150f9c22adc4e444c63",
+    "wof:geomhash":"d24151deac74eb142ef28df62061c669",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -128,7 +129,7 @@
         }
     ],
     "wof:id":421192909,
-    "wof:lastmodified":1690876122,
+    "wof:lastmodified":1695886788,
     "wof:name":"Kyela",
     "wof:parent_id":85679641,
     "wof:placetype":"county",

--- a/data/421/193/165/421193165.geojson
+++ b/data/421/193/165/421193165.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.019942,
-    "geom:area_square_m":12512177872.943417,
+    "geom:area_square_m":12512177399.100542,
     "geom:bbox":"37.137221,-7.914814,38.515742,-6.188492",
     "geom:latitude":-7.194211,
     "geom:longitude":37.84133,
@@ -117,12 +117,13 @@
         "qs_pg:id":482505,
         "wd:id":"Q3710547"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TZ",
     "wof:created":1459009762,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"0242e7c67af0eed94b540b7292e4673b",
+    "wof:geomhash":"92163bfa33b19a91a6ae4e22fc5eb820",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -132,7 +133,7 @@
         }
     ],
     "wof:id":421193165,
-    "wof:lastmodified":1690876124,
+    "wof:lastmodified":1695886784,
     "wof:name":"Morogoro",
     "wof:parent_id":85679677,
     "wof:placetype":"county",

--- a/data/421/194/823/421194823.geojson
+++ b/data/421/194/823/421194823.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.019149,
-    "geom:area_square_m":235489528.707484,
+    "geom:area_square_m":235489364.374175,
     "geom:bbox":"39.181401,-6.040009,39.401207,-5.892387",
     "geom:latitude":-5.97808,
     "geom:longitude":39.269877,
@@ -91,12 +91,13 @@
         "hasc:id":"TZ.ZN.NB",
         "qs_pg:id":7347
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TZ",
     "wof:created":1459009820,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"e23e239655af764c797ad834357caafd",
+    "wof:geomhash":"fe969014b3d3f274fb717d82527a36c1",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -106,7 +107,7 @@
         }
     ],
     "wof:id":421194823,
-    "wof:lastmodified":1627522862,
+    "wof:lastmodified":1695886576,
     "wof:name":"Kaskazini B",
     "wof:parent_id":85679695,
     "wof:placetype":"county",

--- a/data/421/198/067/421198067.geojson
+++ b/data/421/198/067/421198067.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.018841,
-    "geom:area_square_m":232099262.028202,
+    "geom:area_square_m":232099392.274944,
     "geom:bbox":"39.672829,-5.048808,39.876199,-4.864378",
     "geom:latitude":-4.971815,
     "geom:longitude":39.77609,
@@ -110,12 +110,13 @@
         "qs_pg:id":354502,
         "wd:id":"Q6837342"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TZ",
     "wof:created":1459009935,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"c8d12f28dc5f6d93a6b639ee1465beb9",
+    "wof:geomhash":"d87d7b00c198b4b7e9ea292a9e229ebf",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -125,7 +126,7 @@
         }
     ],
     "wof:id":421198067,
-    "wof:lastmodified":1690876134,
+    "wof:lastmodified":1695886583,
     "wof:name":"Micheweni",
     "wof:parent_id":85679683,
     "wof:placetype":"county",

--- a/data/421/198/449/421198449.geojson
+++ b/data/421/198/449/421198449.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.030255,
-    "geom:area_square_m":370702516.868663,
+    "geom:area_square_m":370702623.454625,
     "geom:bbox":"35.581148,-7.854713,35.823232,-7.641013",
     "geom:latitude":-7.733797,
     "geom:longitude":35.708653,
@@ -91,12 +91,13 @@
         "hasc:id":"TZ.IG.IM",
         "qs_pg:id":424741
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TZ",
     "wof:created":1459009948,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"60a89ac7d9d97e07585e1f35326b509a",
+    "wof:geomhash":"c04280dbb9023d5e0e515f1eaacac294",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -106,7 +107,7 @@
         }
     ],
     "wof:id":421198449,
-    "wof:lastmodified":1627522860,
+    "wof:lastmodified":1695886573,
     "wof:name":"Iringa Urban",
     "wof:parent_id":85679711,
     "wof:placetype":"county",

--- a/data/421/198/913/421198913.geojson
+++ b/data/421/198/913/421198913.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.059631,
-    "geom:area_square_m":731883641.355804,
+    "geom:area_square_m":731883766.614334,
     "geom:bbox":"39.191582,-7.179419,39.552886,-6.813017",
     "geom:latitude":-6.976037,
     "geom:longitude":39.406205,
@@ -132,12 +132,13 @@
         "wd:id":"Q2571801",
         "wk:page":"Temeke District"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TZ",
     "wof:created":1459009965,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"61bfd1613f5d874da7a6dd5b790eb552",
+    "wof:geomhash":"1d698dcebca7fa5da53af418db69c29f",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -147,7 +148,7 @@
         }
     ],
     "wof:id":421198913,
-    "wof:lastmodified":1690876134,
+    "wof:lastmodified":1695886789,
     "wof:name":"Temeke",
     "wof:parent_id":85679675,
     "wof:placetype":"county",

--- a/data/421/202/045/421202045.geojson
+++ b/data/421/202/045/421202045.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.017792,
-    "geom:area_square_m":218722165.946153,
+    "geom:area_square_m":218722082.200065,
     "geom:bbox":"39.199737,-6.321643,39.309957,-6.027276",
     "geom:latitude":-6.167693,
     "geom:longitude":39.251392,
@@ -90,12 +90,13 @@
         "hasc:id":"TZ.ZW.WE",
         "qs_pg:id":218427
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TZ",
     "wof:created":1459010102,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"c30915e56786f1d9f05c3875c1222792",
+    "wof:geomhash":"567bd89308ba200609d570921fa24ec2",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -105,7 +106,7 @@
         }
     ],
     "wof:id":421202045,
-    "wof:lastmodified":1642551794,
+    "wof:lastmodified":1695886523,
     "wof:name":"Magharibi",
     "wof:parent_id":85679699,
     "wof:placetype":"county",

--- a/data/421/202/229/421202229.geojson
+++ b/data/421/202/229/421202229.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.044077,
-    "geom:area_square_m":541264521.100291,
+    "geom:area_square_m":541264623.039173,
     "geom:bbox":"39.00629,-6.874,39.288775,-6.564077",
     "geom:latitude":-6.728189,
     "geom:longitude":39.142115,
@@ -91,12 +91,13 @@
         "hasc:id":"TZ.DS.KI",
         "qs_pg:id":220072
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TZ",
     "wof:created":1459010109,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"60101460ae1184ddeeeb52c4cb4777f0",
+    "wof:geomhash":"75f4921bf701ab69220e425d3924aeb4",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -106,7 +107,7 @@
         }
     ],
     "wof:id":421202229,
-    "wof:lastmodified":1627522863,
+    "wof:lastmodified":1695886577,
     "wof:name":"Kinondoni",
     "wof:parent_id":85679675,
     "wof:placetype":"county",

--- a/data/421/202/555/421202555.geojson
+++ b/data/421/202/555/421202555.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.073463,
-    "geom:area_square_m":906886476.14621,
+    "geom:area_square_m":906886268.440603,
     "geom:bbox":"37.05414,-3.505821,37.320162,-2.97427",
     "geom:latitude":-3.289209,
     "geom:longitude":37.200541,
@@ -135,12 +135,13 @@
         "wd:id":"Q1364658",
         "wk:page":"Hai District"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TZ",
     "wof:created":1459010122,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"8fa422d5723a46153ee160a2898bcf2e",
+    "wof:geomhash":"33efe775040d6724559d84d8d2f3c09b",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -150,7 +151,7 @@
         }
     ],
     "wof:id":421202555,
-    "wof:lastmodified":1690876126,
+    "wof:lastmodified":1695886784,
     "wof:name":"Hai",
     "wof:parent_id":85679737,
     "wof:placetype":"county",

--- a/data/421/203/227/421203227.geojson
+++ b/data/421/203/227/421203227.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.160167,
-    "geom:area_square_m":1976287130.476675,
+    "geom:area_square_m":1976287563.096793,
     "geom:bbox":"37.409485,-3.937223,37.952809,-3.430986",
     "geom:latitude":-3.731624,
     "geom:longitude":37.641787,
@@ -114,12 +114,13 @@
         "wd:id":"Q6944667",
         "wk:page":"Mwanga District"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TZ",
     "wof:created":1459010144,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"68e5bb2f534fce54dbc468bea93e9029",
+    "wof:geomhash":"2c983c779c5b508b83cf23cbc91ee3ca",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -129,7 +130,7 @@
         }
     ],
     "wof:id":421203227,
-    "wof:lastmodified":1690876126,
+    "wof:lastmodified":1695886590,
     "wof:name":"Mwanga",
     "wof:parent_id":85679737,
     "wof:placetype":"county",

--- a/data/421/203/229/421203229.geojson
+++ b/data/421/203/229/421203229.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.143907,
-    "geom:area_square_m":1770951927.812482,
+    "geom:area_square_m":1770951923.026602,
     "geom:bbox":"38.643098,-5.966766,39.042458,-5.263328",
     "geom:latitude":-5.595657,
     "geom:longitude":38.816944,
@@ -149,12 +149,13 @@
         "qs_pg:id":230298,
         "wd:id":"Q15265297"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TZ",
     "wof:created":1459010144,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"0acfb37895f2f79aa32e7a10f947d536",
+    "wof:geomhash":"8c9961cdeabfd5b4de71fe01bd5d4943",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -164,7 +165,7 @@
         }
     ],
     "wof:id":421203229,
-    "wof:lastmodified":1690876125,
+    "wof:lastmodified":1695886784,
     "wof:name":"Pangani",
     "wof:parent_id":85679747,
     "wof:placetype":"county",

--- a/data/421/204/027/421204027.geojson
+++ b/data/421/204/027/421204027.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.963517,
-    "geom:area_square_m":11825576813.897255,
+    "geom:area_square_m":11825576043.520817,
     "geom:bbox":"36.477696,-7.872722,37.497724,-6.042227",
     "geom:latitude":-6.975142,
     "geom:longitude":36.999535,
@@ -168,12 +168,13 @@
         "qs_pg:id":237209,
         "wd:id":"Q6408136"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TZ",
     "wof:created":1459010171,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"5394650765caa3c4d46f370b373f3c60",
+    "wof:geomhash":"8b4e9a330a80e8d81c3d05ad6d34aeba",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -183,7 +184,7 @@
         }
     ],
     "wof:id":421204027,
-    "wof:lastmodified":1690876125,
+    "wof:lastmodified":1695886784,
     "wof:name":"Kilosa",
     "wof:parent_id":85679677,
     "wof:placetype":"county",

--- a/data/856/322/27/85632227.geojson
+++ b/data/856/322/27/85632227.geojson
@@ -1173,6 +1173,7 @@
         "hasc:id":"TZ",
         "icao:code":"5H",
         "ioc:id":"TAN",
+        "iso:code":"TZ",
         "itu:id":"TZA",
         "loc:id":"n80121275",
         "m49:code":"834",
@@ -1187,6 +1188,7 @@
         "wk:page":"Tanzania",
         "wmo:id":"TN"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"TZ",
     "wof:country_alpha3":"TZA",
     "wof:geom_alt":[
@@ -1210,7 +1212,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1694639535,
+    "wof:lastmodified":1695881193,
     "wof:name":"Tanzania",
     "wof:parent_id":102191573,
     "wof:placetype":"country",

--- a/data/856/796/41/85679641.geojson
+++ b/data/856/796/41/85679641.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":4.893016,
-    "geom:area_square_m":59875983017.146843,
+    "geom:area_square_m":59875982733.287933,
     "geom:bbox":"32.020008,-9.718722,34.968066,-6.86511",
     "geom:latitude":-8.2301,
     "geom:longitude":33.381136,
@@ -312,17 +312,19 @@
         "gn:id":154375,
         "gp:id":2347360,
         "hasc:id":"TZ.MB",
+        "iso:code":"TZ-14",
         "iso:id":"TZ-14",
         "qs_pg:id":319166,
         "unlc:id":"TZ-14",
         "wd:id":"Q458382",
         "wk:page":"Mbeya Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"TZ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"a2c9fa255688abd8039e763618203f1a",
+    "wof:geomhash":"aafeb20f4dc18f191c9f65978028582c",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -339,7 +341,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1690876097,
+    "wof:lastmodified":1695884894,
     "wof:name":"Mbeya",
     "wof:parent_id":85632227,
     "wof:placetype":"region",

--- a/data/856/796/45/85679645.geojson
+++ b/data/856/796/45/85679645.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.797669,
-    "geom:area_square_m":22012158345.553261,
+    "geom:area_square_m":22012157993.99905,
     "geom:bbox":"30.49938,-9.073342,32.453776,-6.884823",
     "geom:latitude":-7.984935,
     "geom:longitude":31.408217,
@@ -311,16 +311,18 @@
         "gn:id":150442,
         "gp:id":2347375,
         "hasc:id":"TZ.RU",
+        "iso:code":"TZ-20",
         "iso:id":"TZ-20",
         "qs_pg:id":1114956,
         "wd:id":"Q153329",
         "wk:page":"Rukwa Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"TZ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"e35591f10bdec485b9845d945f6e3d8f",
+    "wof:geomhash":"42059922d36efae9903d558d36d56c9a",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -337,7 +339,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1690876091,
+    "wof:lastmodified":1695884889,
     "wof:name":"Rukwa",
     "wof:parent_id":85632227,
     "wof:placetype":"region",

--- a/data/856/796/51/85679651.geojson
+++ b/data/856/796/51/85679651.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.072333,
-    "geom:area_square_m":889117940.482669,
+    "geom:area_square_m":889118114.517875,
     "geom:bbox":"39.269071,-6.478158,39.580349,-6.021441",
     "geom:latitude":-6.238768,
     "geom:longitude":39.423212,
@@ -269,15 +269,17 @@
         "gn:id":148728,
         "gp:id":2347372,
         "hasc:id":"TZ.ZS",
+        "iso:code":"TZ-11",
         "iso:id":"TZ-11",
         "qs_pg:id":1135420,
         "wd:id":"Q643120"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"TZ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"bee3003a4319b85c6b36bbf7fbf5d413",
+    "wof:geomhash":"fa7ba62bbb605762df73cfb10e9794b3",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -294,7 +296,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1690876091,
+    "wof:lastmodified":1695885131,
     "wof:name":"Zanzibar South and Central",
     "wof:parent_id":85632227,
     "wof:placetype":"region",

--- a/data/856/796/55/85679655.geojson
+++ b/data/856/796/55/85679655.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.940995,
-    "geom:area_square_m":11621827357.442118,
+    "geom:area_square_m":11621826644.517038,
     "geom:bbox":"31.93281,-3.43541,33.789809,-1.667174",
     "geom:latitude":-2.767529,
     "geom:longitude":33.004505,
@@ -319,17 +319,19 @@
         "gn:id":152219,
         "gp:id":2347363,
         "hasc:id":"TZ.MZ",
+        "iso:code":"TZ-18",
         "iso:id":"TZ-18",
         "qs_pg:id":1285541,
         "unlc:id":"TZ-18",
         "wd:id":"Q331153",
         "wk:page":"Mwanza Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"TZ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"ca6c69d3e093a11ae8034afee0f8bf0e",
+    "wof:geomhash":"1002e3f04fadcad30e1f632079b51208",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -346,7 +348,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1690876096,
+    "wof:lastmodified":1695884893,
     "wof:name":"Mwanza",
     "wof:parent_id":85632227,
     "wof:placetype":"region",

--- a/data/856/796/57/85679657.geojson
+++ b/data/856/796/57/85679657.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.337063,
-    "geom:area_square_m":16497471223.892628,
+    "geom:area_square_m":16497471401.650349,
     "geom:bbox":"31.682261,-4.3243,34.233575,-3.195402",
     "geom:latitude":-3.751946,
     "geom:longitude":32.936085,
@@ -308,16 +308,18 @@
         "gn:id":150004,
         "gp:id":2347366,
         "hasc:id":"TZ.SY",
+        "iso:code":"TZ-22",
         "iso:id":"TZ-22",
         "qs_pg:id":1047577,
         "wd:id":"Q153339",
         "wk:page":"Shinyanga Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"TZ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"a7c9395ec092756207f9d79bd9306e5b",
+    "wof:geomhash":"3b4cbbe9e3171740a8d46d6a3a8d8bfb",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -334,7 +336,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1690876090,
+    "wof:lastmodified":1695884888,
     "wof:name":"Shinyanga",
     "wof:parent_id":85632227,
     "wof:placetype":"region",

--- a/data/856/796/61/85679661.geojson
+++ b/data/856/796/61/85679661.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":6.150316,
-    "geom:area_square_m":75723087725.456955,
+    "geom:area_square_m":75723089178.316574,
     "geom:bbox":"31.038017,-6.976729,34.242038,-3.876684",
     "geom:latitude":-5.263757,
     "geom:longitude":32.821586,
@@ -306,17 +306,19 @@
         "gn:id":149653,
         "gp:id":2347368,
         "hasc:id":"TZ.TB",
+        "iso:code":"TZ-24",
         "iso:id":"TZ-24",
         "qs_pg:id":424134,
         "unlc:id":"TZ-24",
         "wd:id":"Q153335",
         "wk:page":"Tabora Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"TZ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"39b01223ad4d2c5f9c774cee17886b3f",
+    "wof:geomhash":"67070d770c5eb71909472df1e69a8b76",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -333,7 +335,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1690876089,
+    "wof:lastmodified":1695884887,
     "wof:name":"Tabora",
     "wof:parent_id":85632227,
     "wof:placetype":"region",

--- a/data/856/796/65/85679665.geojson
+++ b/data/856/796/65/85679665.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.154179,
-    "geom:area_square_m":26618423332.920521,
+    "geom:area_square_m":26618424235.481045,
     "geom:bbox":"30.410674,-3.360234,32.617735,-0.983143",
     "geom:latitude":-2.028889,
     "geom:longitude":31.184128,
@@ -305,16 +305,18 @@
         "gn:id":148679,
         "gp:id":2347370,
         "hasc:id":"TZ.KG",
+        "iso:code":"TZ-05",
         "iso:id":"TZ-05",
         "qs_pg:id":891340,
         "wd:id":"Q309190",
         "wk:page":"Kagera Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"TZ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"6dfb25dabfd6a51be946f1b47d381394",
+    "wof:geomhash":"4901a8b1fe9dadc566c6a7317228aa99",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -331,7 +333,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1690876095,
+    "wof:lastmodified":1695884892,
     "wof:name":"Kagera",
     "wof:parent_id":85632227,
     "wof:placetype":"region",

--- a/data/856/796/69/85679669.geojson
+++ b/data/856/796/69/85679669.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.962058,
-    "geom:area_square_m":36505855962.643929,
+    "geom:area_square_m":36505856263.671188,
     "geom:bbox":"29.589529,-6.570679,31.492551,-2.827975",
     "geom:latitude":-4.587271,
     "geom:longitude":30.56107,
@@ -315,17 +315,19 @@
         "gn:id":157732,
         "gp:id":2347356,
         "hasc:id":"TZ.KM",
+        "iso:code":"TZ-08",
         "iso:id":"TZ-08",
         "qs_pg:id":890111,
         "unlc:id":"TZ-08",
         "wd:id":"Q747943",
         "wk:page":"Kigoma Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"TZ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"9b169c60ea41795fbee0775974127dcd",
+    "wof:geomhash":"37062675fcaae6146d4231abaf2f011d",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -342,7 +344,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1690876090,
+    "wof:lastmodified":1695884888,
     "wof:name":"Kigoma",
     "wof:parent_id":85632227,
     "wof:placetype":"region",

--- a/data/856/796/75/85679675.geojson
+++ b/data/856/796/75/85679675.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.13357,
-    "geom:area_square_m":1639710281.962422,
+    "geom:area_square_m":1639710551.360916,
     "geom:bbox":"39.00629,-7.179419,39.552886,-6.564077",
     "geom:latitude":-6.884585,
     "geom:longitude":39.261608,
@@ -304,17 +304,19 @@
         "gn:id":160260,
         "gp:id":2347374,
         "hasc:id":"TZ.DS",
+        "iso:code":"TZ-02",
         "iso:id":"TZ-02",
         "qs_pg:id":1114955,
         "unlc:id":"TZ-02",
         "wd:id":"Q557539",
         "wk:page":"Dar es Salaam Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"TZ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"c5070d4dbf34fbd4ab03131c49d4aee2",
+    "wof:geomhash":"fc6660829890b459765bef8561150451",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -331,7 +333,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1690876093,
+    "wof:lastmodified":1695884562,
     "wof:name":"Dar-es-Salaam",
     "wof:parent_id":85632227,
     "wof:placetype":"region",

--- a/data/856/796/77/85679677.geojson
+++ b/data/856/796/77/85679677.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":5.751923,
-    "geom:area_square_m":70432656500.908279,
+    "geom:area_square_m":70432654412.007706,
     "geom:bbox":"35.323258,-9.921631,38.515742,-5.800069",
     "geom:latitude":-7.920821,
     "geom:longitude":36.988318,
@@ -321,17 +321,19 @@
         "gn:id":153214,
         "gp:id":2347361,
         "hasc:id":"TZ.MO",
+        "iso:code":"TZ-16",
         "iso:id":"TZ-16",
         "qs_pg:id":319167,
         "unlc:id":"TZ-16",
         "wd:id":"Q458388",
         "wk:page":"Morogoro Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"TZ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"60cfd8c648a71bb1861d1b8da11b7a19",
+    "wof:geomhash":"20ed12a729fef718707741f1e5dac443",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -348,7 +350,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1690876098,
+    "wof:lastmodified":1695884895,
     "wof:name":"Morogoro",
     "wof:parent_id":85632227,
     "wof:placetype":"region",

--- a/data/856/796/83/85679683.geojson
+++ b/data/856/796/83/85679683.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.042902,
-    "geom:area_square_m":528438212.312796,
+    "geom:area_square_m":528438482.702534,
     "geom:bbox":"39.630091,-5.208608,39.876199,-4.864378",
     "geom:latitude":-5.043164,
     "geom:longitude":39.770983,
@@ -302,17 +302,19 @@
         "gn:id":150733,
         "gp:id":2347364,
         "hasc:id":"TZ.PN",
+        "iso:code":"TZ-06",
         "iso:id":"TZ-06",
         "qs_pg:id":1285545,
         "unlc:id":"TZ-06",
         "wd:id":"Q498073",
         "wk:page":"Pemba North Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"TZ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"41287c19c768a4d5175c902ca1f0a0e8",
+    "wof:geomhash":"018f9e2fd532f3fe2f6059ce793b16cb",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -329,7 +331,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1690876098,
+    "wof:lastmodified":1695884895,
     "wof:name":"Kaskazini-Pemba",
     "wof:parent_id":85632227,
     "wof:placetype":"region",

--- a/data/856/796/87/85679687.geojson
+++ b/data/856/796/87/85679687.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.038777,
-    "geom:area_square_m":477413286.358835,
+    "geom:area_square_m":477413222.954241,
     "geom:bbox":"39.56271,-5.487027,39.855784,-5.15853",
     "geom:latitude":-5.320267,
     "geom:longitude":39.736204,
@@ -299,17 +299,19 @@
         "gn:id":150732,
         "gp:id":2347371,
         "hasc:id":"TZ.PS",
+        "iso:code":"TZ-10",
         "iso:id":"TZ-10",
         "qs_pg:id":221187,
         "unlc:id":"TZ-10",
         "wd:id":"Q498067",
         "wk:page":"Pemba South Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"TZ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"5a5ad033b5c8dc167ffc3a0d81da77de",
+    "wof:geomhash":"123c9c4d0973303d1e2ba76cac02a464",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -326,7 +328,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1690876092,
+    "wof:lastmodified":1695884889,
     "wof:name":"Kusini-Pemba",
     "wof:parent_id":85632227,
     "wof:placetype":"region",

--- a/data/856/796/91/85679691.geojson
+++ b/data/856/796/91/85679691.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.612885,
-    "geom:area_square_m":32047909663.42577,
+    "geom:area_square_m":32047908779.828861,
     "geom:bbox":"37.794138,-8.512519,39.90845,-5.841273",
     "geom:latitude":-7.253122,
     "geom:longitude":38.649148,
@@ -317,17 +317,19 @@
         "gn:id":150602,
         "gp:id":2347353,
         "hasc:id":"TZ.PW",
+        "iso:code":"TZ-19",
         "iso:id":"TZ-19",
         "qs_pg:id":1064630,
         "unlc:id":"TZ-19",
         "wd:id":"Q458412",
         "wk:page":"Pwani Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"TZ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"0d4f372e0902f28938d9d2e5f379f0ec",
+    "wof:geomhash":"c341834f323ff40bbad090a7d6d06f8f",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -344,7 +346,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1690876094,
+    "wof:lastmodified":1695884890,
     "wof:name":"Pwani",
     "wof:parent_id":85632227,
     "wof:placetype":"region",

--- a/data/856/796/95/85679695.geojson
+++ b/data/856/796/95/85679695.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.037896,
-    "geom:area_square_m":466088571.877253,
+    "geom:area_square_m":466088572.445428,
     "geom:bbox":"39.181401,-6.040009,39.401207,-5.721897",
     "geom:latitude":-5.918897,
     "geom:longitude":39.287957,
@@ -301,17 +301,19 @@
         "gn:id":148725,
         "gp:id":2347373,
         "hasc:id":"TZ.ZN",
+        "iso:code":"TZ-07",
         "iso:id":"TZ-07",
         "qs_pg:id":221188,
         "unlc:id":"TZ-07",
         "wd:id":"Q147116",
         "wk:page":"Unguja North Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"TZ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"dfc171c1cfae6b78367750d914fc4dba",
+    "wof:geomhash":"124b8f148b6f09e9fbe7cfb6479a9ad9",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -328,7 +330,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1690876089,
+    "wof:lastmodified":1695884888,
     "wof:name":"Kaskazini-Unguja",
     "wof:parent_id":85632227,
     "wof:placetype":"region",

--- a/data/856/796/99/85679699.geojson
+++ b/data/856/796/99/85679699.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.019054,
-    "geom:area_square_m":234246831.0791,
+    "geom:area_square_m":234246732.848787,
     "geom:bbox":"39.185588,-6.321643,39.309957,-6.027276",
     "geom:latitude":-6.167597,
     "geom:longitude":39.248609,
@@ -317,15 +317,17 @@
         "gn:id":148724,
         "gp:id":2347376,
         "hasc:id":"TZ.ZW",
+        "iso:code":"TZ-15",
         "iso:id":"TZ-15",
         "qs_pg:id":1135421,
         "wd:id":"Q180822"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"TZ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"ea6e2ab62a2e23a92fd6e7a97bd5052e",
+    "wof:geomhash":"5a358fc117f2e0c11a2d413a1bcfef6c",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -342,7 +344,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1690876096,
+    "wof:lastmodified":1695885132,
     "wof:name":"Zanzibar West",
     "wof:parent_id":85632227,
     "wof:placetype":"region",

--- a/data/856/797/05/85679705.geojson
+++ b/data/856/797/05/85679705.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":3.419348,
-    "geom:area_square_m":42051443940.657265,
+    "geom:area_square_m":42051444622.584244,
     "geom:bbox":"35.05273,-7.377303,36.963997,-4.312735",
     "geom:latitude":-5.926967,
     "geom:longitude":35.921518,
@@ -288,17 +288,19 @@
         "gn:id":160192,
         "gp:id":2347354,
         "hasc:id":"TZ.DO",
+        "iso:code":"TZ-03",
         "iso:id":"TZ-03",
         "qs_pg:id":1083878,
         "unlc:id":"TZ-03",
         "wd:id":"Q213268",
         "wk:page":"Dodoma Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"TZ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"6888592422490f940b939ab826ce2ff3",
+    "wof:geomhash":"5611f6098363c168f529acbfa6f2df14",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -315,7 +317,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1690876084,
+    "wof:lastmodified":1695884884,
     "wof:name":"Dodoma",
     "wof:parent_id":85632227,
     "wof:placetype":"region",

--- a/data/856/797/11/85679711.geojson
+++ b/data/856/797/11/85679711.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.991096,
-    "geom:area_square_m":36641892226.044792,
+    "geom:area_square_m":36641892620.649216,
     "geom:bbox":"34.193339,-9.040651,36.844811,-6.886497",
     "geom:latitude":-7.801272,
     "geom:longitude":35.475212,
@@ -314,16 +314,18 @@
         "gn:id":159067,
         "gp:id":2347355,
         "hasc:id":"TZ.IG",
+        "iso:code":"TZ-04",
         "iso:id":"TZ-04",
         "qs_pg:id":1083879,
         "wd:id":"Q309352",
         "wk:page":"Iringa Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"TZ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"36d2400f6ce0e3d72b76ff22be2ed2a0",
+    "wof:geomhash":"92f1dcbacf5b49a387bbbd55ba42f739",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -340,7 +342,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1690876085,
+    "wof:lastmodified":1695884885,
     "wof:name":"Iringa",
     "wof:parent_id":85632227,
     "wof:placetype":"region",

--- a/data/856/797/13/85679713.geojson
+++ b/data/856/797/13/85679713.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":5.339188,
-    "geom:area_square_m":65114053380.092934,
+    "geom:area_square_m":65114053645.552368,
     "geom:bbox":"36.868123,-10.735825,39.979933,-7.932525",
     "geom:latitude":-9.481389,
     "geom:longitude":38.40203,
@@ -309,17 +309,19 @@
         "gn:id":155946,
         "gp:id":2347358,
         "hasc:id":"TZ.LI",
+        "iso:code":"TZ-12",
         "iso:id":"TZ-12",
         "qs_pg:id":319165,
         "unlc:id":"TZ-12",
         "wd:id":"Q309339",
         "wk:page":"Lindi Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"TZ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"3618b5ce01c3ae293a40816f235bc59a",
+    "wof:geomhash":"9f5d56315ae2ba34519cafd6d0358f63",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -336,7 +338,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1690876089,
+    "wof:lastmodified":1695884888,
     "wof:name":"Lindi",
     "wof:parent_id":85632227,
     "wof:placetype":"region",

--- a/data/856/797/17/85679717.geojson
+++ b/data/856/797/17/85679717.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.473448,
-    "geom:area_square_m":17898003667.700417,
+    "geom:area_square_m":17898003333.009602,
     "geom:bbox":"37.999048,-11.417696,40.444735,-10.125081",
     "geom:latitude":-10.77597,
     "geom:longitude":39.11302,
@@ -315,17 +315,19 @@
         "gn:id":877744,
         "gp:id":2347362,
         "hasc:id":"TZ.MT",
+        "iso:code":"TZ-17",
         "iso:id":"TZ-17",
         "qs_pg:id":895006,
         "unlc:id":"TZ-17",
         "wd:id":"Q499465",
         "wk:page":"Mtwara Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"TZ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"1c490ad7a530aba7760882294cb72fa2",
+    "wof:geomhash":"0d9477c9b66a654abe55b24dead670ba",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -342,7 +344,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1690876085,
+    "wof:lastmodified":1695884885,
     "wof:name":"Mtwara",
     "wof:parent_id":85632227,
     "wof:placetype":"region",

--- a/data/856/797/23/85679723.geojson
+++ b/data/856/797/23/85679723.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":5.182564,
-    "geom:area_square_m":62961306249.784286,
+    "geom:area_square_m":62961305368.270935,
     "geom:bbox":"34.568596,-11.762349,38.112979,-9.248488",
     "geom:latitude":-10.72432,
     "geom:longitude":36.251152,
@@ -315,17 +315,19 @@
         "gn:id":877416,
         "gp:id":2347365,
         "hasc:id":"TZ.RV",
+        "iso:code":"TZ-21",
         "iso:id":"TZ-21",
         "qs_pg:id":235651,
         "unlc:id":"TZ-21",
         "wd:id":"Q115318",
         "wk:page":"Ruvuma Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"TZ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"fa76d15b2432832df5c0e7ac3f911e08",
+    "wof:geomhash":"5b9b219426cb52ac0b95b1f50cb1840e",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -342,7 +344,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1690876088,
+    "wof:lastmodified":1695884887,
     "wof:name":"Ruvuma",
     "wof:parent_id":85632227,
     "wof:placetype":"region",

--- a/data/856/797/27/85679727.geojson
+++ b/data/856/797/27/85679727.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":3.964692,
-    "geom:area_square_m":48771368461.212845,
+    "geom:area_square_m":48771366121.758331,
     "geom:bbox":"33.486549,-7.534773,35.356383,-3.800776",
     "geom:latitude":-5.745442,
     "geom:longitude":34.495386,
@@ -303,17 +303,19 @@
         "gn:id":149876,
         "gp:id":2347367,
         "hasc:id":"TZ.SD",
+        "iso:code":"TZ-23",
         "iso:id":"TZ-23",
         "qs_pg:id":1285546,
         "unlc:id":"TZ-23",
         "wd:id":"Q153326",
         "wk:page":"Singida Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"TZ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"fc59bbba6143f1d3efa35a1616f43cee",
+    "wof:geomhash":"0ada8ee3ae7b374b73719ab384fba1e4",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -330,7 +332,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1690876084,
+    "wof:lastmodified":1695884885,
     "wof:name":"Singida",
     "wof:parent_id":85632227,
     "wof:placetype":"region",

--- a/data/856/797/31/85679731.geojson
+++ b/data/856/797/31/85679731.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":3.006851,
-    "geom:area_square_m":37129696214.12117,
+    "geom:area_square_m":37129697331.008774,
     "geom:bbox":"34.749262,-4.148158,37.429372,-1.686907",
     "geom:latitude":-2.949007,
     "geom:longitude":35.942628,
@@ -319,17 +319,19 @@
         "gn:id":161322,
         "gp:id":2347352,
         "hasc:id":"TZ.AS",
+        "iso:code":"TZ-01",
         "iso:id":"TZ-01",
         "qs_pg:id":914054,
         "unlc:id":"TZ-01",
         "wd:id":"Q329261",
         "wk:page":"Arusha Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"TZ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"58f3c16be828873e59718a3911d482a1",
+    "wof:geomhash":"2a11250d3fc7c7a3cd6e6e2dea7420cf",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -346,7 +348,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1690876086,
+    "wof:lastmodified":1695884886,
     "wof:name":"Arusha",
     "wof:parent_id":85632227,
     "wof:placetype":"region",

--- a/data/856/797/33/85679733.geojson
+++ b/data/856/797/33/85679733.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":3.786449,
-    "geom:area_square_m":46671347421.737999,
+    "geom:area_square_m":46671347411.017166,
     "geom:bbox":"34.86441,-5.951309,38.000054,-3.448487",
     "geom:latitude":-4.533697,
     "geom:longitude":36.548099,
@@ -306,17 +306,19 @@
         "gn:id":435764,
         "gp:id":56025085,
         "hasc:id":"TZ.MY",
+        "iso:code":"TZ-26",
         "iso:id":"TZ-26",
         "qs_pg:id":1081970,
         "unlc:id":"TZ-26",
         "wd:id":"Q331117",
         "wk:page":"Manyara Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"TZ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"68cf17465229e7225ea4ecb57c4a88c4",
+    "wof:geomhash":"4919edfdf1d5e9e98d474b436f325b75",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -333,7 +335,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1690876083,
+    "wof:lastmodified":1695884885,
     "wof:name":"Manyara",
     "wof:parent_id":85632227,
     "wof:placetype":"region",

--- a/data/856/797/37/85679737.geojson
+++ b/data/856/797/37/85679737.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.073609,
-    "geom:area_square_m":13246317756.768799,
+    "geom:area_square_m":13246318348.542793,
     "geom:bbox":"36.889585,-4.61371,38.403605,-2.849522",
     "geom:latitude":-3.760131,
     "geom:longitude":37.640144,
@@ -319,17 +319,19 @@
         "gn:id":157449,
         "gp:id":2347357,
         "hasc:id":"TZ.KL",
+        "iso:code":"TZ-09",
         "iso:id":"TZ-09",
         "qs_pg:id":219628,
         "unlc:id":"TZ-09",
         "wd:id":"Q328922",
         "wk:page":"Kilimanjaro Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"TZ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"d633259d12c8f5e1c88d377e6d7c747f",
+    "wof:geomhash":"17beabe19dc2793f82cb3c5ee259593d",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -346,7 +348,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1690876087,
+    "wof:lastmodified":1695884886,
     "wof:name":"Kilimanjaro",
     "wof:parent_id":85632227,
     "wof:placetype":"region",

--- a/data/856/797/43/85679743.geojson
+++ b/data/856/797/43/85679743.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.714187,
-    "geom:area_square_m":21184829916.723183,
+    "geom:area_square_m":21184829507.520706,
     "geom:bbox":"33.202932,-2.498291,35.265917,-1.026221",
     "geom:latitude":-1.852783,
     "geom:longitude":34.395288,
@@ -312,17 +312,19 @@
         "gn:id":154775,
         "gp:id":2347359,
         "hasc:id":"TZ.MA",
+        "iso:code":"TZ-13",
         "iso:id":"TZ-13",
         "qs_pg:id":454604,
         "unlc:id":"TZ-13",
         "wd:id":"Q458406",
         "wk:page":"Mara Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"TZ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"2fc74537de8f8c8019ff810a0f50bb94",
+    "wof:geomhash":"6eec61e79d59636fd8bbabc3b1c77795",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -339,7 +341,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1690876086,
+    "wof:lastmodified":1695884886,
     "wof:name":"Mara",
     "wof:parent_id":85632227,
     "wof:placetype":"region",

--- a/data/856/797/47/85679747.geojson
+++ b/data/856/797/47/85679747.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.274992,
-    "geom:area_square_m":28013336328.758919,
+    "geom:area_square_m":28013337281.997082,
     "geom:bbox":"37.018946,-6.019738,39.220056,-4.10869",
     "geom:latitude":-5.217078,
     "geom:longitude":38.276488,
@@ -321,17 +321,19 @@
         "gn:id":149595,
         "gp:id":2347369,
         "hasc:id":"TZ.TN",
+        "iso:code":"TZ-25",
         "iso:id":"TZ-25",
         "qs_pg:id":890107,
         "unlc:id":"TZ-25",
         "wd:id":"Q389737",
         "wk:page":"Tanga Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"TZ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"a6ab1b5d79b516eb64b42e44a8f43b96",
+    "wof:geomhash":"42306cd8b90fe851f3076d83034dfcd7",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -348,7 +350,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1690876088,
+    "wof:lastmodified":1695884887,
     "wof:name":"Tanga",
     "wof:parent_id":85632227,
     "wof:placetype":"region",

--- a/data/856/797/51/85679751.geojson
+++ b/data/856/797/51/85679751.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":3.832379,
-    "geom:area_square_m":47091840777.534477,
+    "geom:area_square_m":47091840868.729706,
     "geom:bbox":"29.903001,-7.611911,32.758813,-5.133377",
     "geom:latitude":-6.385262,
     "geom:longitude":31.345777,
@@ -312,15 +312,17 @@
         "gn:id":-99,
         "gp:id":-2347375,
         "hasc:id":"TZ.KA",
+        "iso:code":"TZ-28",
         "iso:id":"TZ-28",
         "unlc:id":"TZ-28",
         "wd:id":"Q153329"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"TZ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"ffb7dc94c72209ad4f870ac9f96de084",
+    "wof:geomhash":"ecdc8d1e318eed1a0fe17ed8fbf93379",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -337,7 +339,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1690876083,
+    "wof:lastmodified":1695884884,
     "wof:name":"Katavi",
     "wof:parent_id":85632227,
     "wof:placetype":"region",

--- a/data/856/797/55/85679755.geojson
+++ b/data/856/797/55/85679755.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.967786,
-    "geom:area_square_m":24297117424.672802,
+    "geom:area_square_m":24297117340.315876,
     "geom:bbox":"33.423074,-4.084633,35.223437,-2.178633",
     "geom:latitude":-3.040795,
     "geom:longitude":34.29276,
@@ -303,15 +303,17 @@
         "gn:id":-99,
         "gp:id":-2347366,
         "hasc:id":"TZ.SI",
+        "iso:code":"TZ-30",
         "iso:id":"TZ-30",
         "unlc:id":"TZ-30",
         "wd:id":"Q153339"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"TZ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"0232358773b0b65380afa598580fb5fc",
+    "wof:geomhash":"32c273889f04d428b85f280de6c14d5d",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -328,7 +330,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1690876087,
+    "wof:lastmodified":1695884887,
     "wof:name":"Simiyu",
     "wof:parent_id":85632227,
     "wof:placetype":"region",

--- a/data/856/797/61/85679761.geojson
+++ b/data/856/797/61/85679761.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.605099,
-    "geom:area_square_m":19813822339.594791,
+    "geom:area_square_m":19813822227.688389,
     "geom:bbox":"31.149676,-4.469112,32.792927,-2.237867",
     "geom:latitude":-3.298882,
     "geom:longitude":31.898657,
@@ -212,15 +212,17 @@
         "fips:code":"TZ28",
         "gp:id":-2347370,
         "hasc:id":"TZ.GE",
+        "iso:code":"TZ-27",
         "iso:id":"TZ-27",
         "unlc:id":"TZ-27",
         "wd:id":"Q4622385"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"TZ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"c2e57baa81a1403a9681aa84279c5d4d",
+    "wof:geomhash":"78123efb277e361c36b4d9012c6836b1",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -237,7 +239,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1690876083,
+    "wof:lastmodified":1695884884,
     "wof:name":"Geita",
     "wof:parent_id":85632227,
     "wof:placetype":"region",

--- a/data/856/797/65/85679765.geojson
+++ b/data/856/797/65/85679765.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.750374,
-    "geom:area_square_m":21349388327.221176,
+    "geom:area_square_m":21349389895.217926,
     "geom:bbox":"33.810973,-10.538403,35.523169,-8.663164",
     "geom:latitude":-9.450256,
     "geom:longitude":34.714039,
@@ -205,15 +205,17 @@
         "gn:id":-99,
         "gp:id":-2347355,
         "hasc:id":"TZ.NJ",
+        "iso:code":"TZ-29",
         "iso:id":"TZ-29",
         "unlc:id":"TZ-29",
         "wd:id":"Q24283486"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"TZ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"ab76b6c1786077f0bcaf065aad457bc8",
+    "wof:geomhash":"dd57eb616ea34b5b89e9546177512e66",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -230,7 +232,7 @@
         "swa",
         "eng"
     ],
-    "wof:lastmodified":1690876086,
+    "wof:lastmodified":1695884887,
     "wof:name":"Njombe",
     "wof:parent_id":85632227,
     "wof:placetype":"region",

--- a/data/890/451/535/890451535.geojson
+++ b/data/890/451/535/890451535.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.018747,
-    "geom:area_square_m":230599043.169845,
+    "geom:area_square_m":230599208.071331,
     "geom:bbox":"39.211521,-5.990818,39.385574,-5.721897",
     "geom:latitude":-5.858446,
     "geom:longitude":39.306423,
@@ -85,12 +85,13 @@
         "hasc:id":"TZ.ZN.NA",
         "qs_pg:id":7346
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TZ",
     "wof:created":1469052783,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"669afeff7a6626059a53966cd1b9e645",
+    "wof:geomhash":"c3f481204b86aee77a3b6eb1c91dbcd3",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -100,7 +101,7 @@
         }
     ],
     "wof:id":890451535,
-    "wof:lastmodified":1627522861,
+    "wof:lastmodified":1695886575,
     "wof:name":"Kaskazini A",
     "wof:parent_id":85679695,
     "wof:placetype":"county",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.